### PR TITLE
Fixes hierarchy widget selectedItem bug

### DIFF
--- a/web_external/js/views/widgets/DatasetHierarchyWidget.js
+++ b/web_external/js/views/widgets/DatasetHierarchyWidget.js
@@ -28,6 +28,12 @@ minerva.views.DatasetHierarchyWidget = minerva.View.extend({
     },
 
     updateModelWithSelectedItems: function () {
+        // if we already have something checked because of selectedItems
+        // then itemListView.checked will be out of date,  recompute it here.
+        // We have a one source of truth problem that needs to be resolved between
+        // itemListView.checked and DataModel.attributes.meta.minerva.selectedItems
+        this.hierarchyWidget.itemListView.recomputeChecked();
+
         var resources = this.hierarchyWidget.getCheckedResources();
         this.dataset.get('meta').minerva.selectedItems = resources.item || [];
         this.dataset.save();


### PR DESCRIPTION
This bug is reproduced by opening a ReadOnlyHierarchyWidget, selecting
an item,  then clicking Use Selected.  Re-opening the same folder in the
widget shows the item as still being selected,  but clicking "Use
Selected" again causes the item to become unselected.

This is because the itemListWidget.checked variable in the
hierarchyWidget is maintaining the same 'checked'  state as
DatasetModel.attributes.meta.minerva.selectedItems.  the selectedItems
variable is used to update the checked boxes on render making it appear
that the box is checked,  when in fact it relies on the
itemListWidget.checked variable.  We will need to clean up the multiple
states so that only one variable tracks this information.