### PR TITLE
Don't use the OSM attribution when using a WMS source

### DIFF
--- a/web_external/js/views/body/MapPanel.js
+++ b/web_external/js/views/body/MapPanel.js
@@ -55,7 +55,7 @@ minerva.views.MapPanel = minerva.View.extend({
         if (!_.contains(this.datasetLayers, dataset.id)) {
             if (dataset.getDatasetType() === 'wms') {
                 var datasetId = dataset.id;
-                var layer = this.map.createLayer('osm');
+                var layer = this.map.createLayer('osm', {attribution: null});
                 this.datasetLayers[datasetId] = layer;
                 this._specifyWmsDatasetLayer(dataset, layer);
 


### PR DESCRIPTION
This should get rid of the duplicate attributions that you were seeing.