### PR TITLE
Handle WMS authentication with encrypted credentials and proxying

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ ijson==2.2.0
 geopy==1.10.0
 owslib==0.9.1
 -e git+https://github.com/Kitware/romanesco.git#egg=romanesco[spark]
+cryptography==1.0.1

--- a/server/constants.py
+++ b/server/constants.py
@@ -26,3 +26,4 @@ class PluginSettings():
     SESSION_FOLDER = 'session'
     GEOJSON_EXTENSION = '.geojson'
     SESSION_FILENAME = 'session.json'
+    CRYPTO_KEY = 'CHANGEME-EykxwRhz0BKiF8-Frc0D1VtBUntKyTrcTk='

--- a/server/loader.py
+++ b/server/loader.py
@@ -20,13 +20,16 @@
 import mako
 import json
 import os
-
+import requests
+import cherrypy
+from base64 import b64encode
 from girder import constants, events
 from girder.utility.model_importer import ModelImporter
 
 from girder.plugins.minerva.rest import \
         analysis, dataset, s3_dataset, session, shapefile, geocode, source, \
         wms_dataset, wms_source
+from girder.plugins.minerva.constants import PluginSettings
 
 
 class CustomAppRoot(object):
@@ -138,6 +141,20 @@ src="http://cdn.jsdelivr.net/bootstrap.daterangepicker/1/daterangepicker.js">
         return self.indexHtml
 
 
+class WmsProxy(object):
+    exposed = True
+
+    def GET(self, url, credentials, **params):
+        from cryptography.fernet import Fernet
+        key = PluginSettings.CRYPTO_KEY
+        f = Fernet(key)
+        credentials = 'Basic ' + b64encode(f.decrypt(bytes(credentials)))
+        headers = {'Authorization': credentials}
+        r = requests.get(url, params=params, headers=headers)
+        cherrypy.response.headers['Content-Type'] = r.headers['content-type']
+        return r.content
+
+
 def validate_settings(event):
     """Validate minerva specific settings."""
     key = event.info['key']
@@ -175,3 +192,4 @@ def load(info):
     info['apiRoot'].minerva_source = source.Source()
     info['apiRoot'].minerva_source_wms = wms_source.WmsSource()
     info['apiRoot'].minerva_dataset_wms = wms_dataset.WmsDataset()
+    info['serverRoot'].wms_proxy = WmsProxy()

--- a/server/rest/wms_dataset.py
+++ b/server/rest/wms_dataset.py
@@ -39,8 +39,6 @@ class WmsDataset(Dataset):
     @loadmodel(map={'wmsSourceId': 'wmsSource'}, model='item',
                level=AccessType.READ)
     def createWmsDataset(self, wmsSource, params):
-        # Get layer legend (TODO// Include authentication in the future)
-        # Legend to be included in the metadata?
         baseURL = wmsSource['meta']['minerva']['wms_params']['base_url']
         parsedUrl = getUrlParts(baseURL)
         typeName = params['typeName']

--- a/server/rest/wms_dataset.py
+++ b/server/rest/wms_dataset.py
@@ -43,7 +43,6 @@ class WmsDataset(Dataset):
         # Legend to be included in the metadata?
         baseURL = wmsSource['meta']['minerva']['wms_params']['base_url']
         parsedUrl = getUrlParts(baseURL)
-        hostName = parsedUrl.netloc
         typeName = params['typeName']
 
         if 'credentials' in wmsSource['meta']['minerva']['wms_params']:

--- a/server/rest/wms_dataset.py
+++ b/server/rest/wms_dataset.py
@@ -16,6 +16,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 ###############################################################################
+from base64 import b64encode
 import httplib
 import binascii
 from girder.api import access
@@ -25,6 +26,7 @@ from girder.api.rest import getUrlParts
 from girder.constants import AccessType
 
 from girder.plugins.minerva.rest.dataset import Dataset
+from girder.plugins.minerva.utility.minerva_utility import decryptCredentials
 
 
 class WmsDataset(Dataset):
@@ -43,12 +45,24 @@ class WmsDataset(Dataset):
         parsedUrl = getUrlParts(baseURL)
         hostName = parsedUrl.netloc
         typeName = params['typeName']
-        conn = httplib.HTTPConnection(hostName)
+
+        if 'credentials' in wmsSource['meta']['minerva']['wms_params']:
+            credentials = (
+                wmsSource['meta']['minerva']['wms_params']['credentials']
+            )
+            basic_auth = 'Basic ' + b64encode(decryptCredentials(credentials))
+            headers = {'Authorization': basic_auth}
+        else:
+            headers = {}
+            credentials = None
+
+        conn = httplib.HTTPConnection(parsedUrl.netloc)
         conn.request("GET",
-                     "/geoserver/ows?service=WMS&request=" +
+                     parsedUrl.path +
+                     "?service=WMS&request=" +
                      "GetLegendGraphic&format=image" +
                      "%2Fpng&width=20&height=20&layer=" +
-                     typeName
+                     typeName, headers=headers
                      )
         response = conn.getresponse()
         legend = binascii.b2a_base64(response.read())
@@ -62,6 +76,8 @@ class WmsDataset(Dataset):
             'type_name': typeName,
             'base_url': baseURL
         }
+        if credentials:
+            minerva_metadata['credentials'] = credentials
         dataset = self.constructDataset(name, minerva_metadata)
         return dataset
     createWmsDataset.description = (

--- a/server/rest/wms_source.py
+++ b/server/rest/wms_source.py
@@ -25,6 +25,7 @@ from girder.api.rest import getUrlParts
 from owslib.wms import WebMapService
 
 from girder.plugins.minerva.rest.source import Source
+from girder.plugins.minerva.utility.minerva_utility import encryptCredentials
 
 
 class WmsSource(Source):
@@ -62,6 +63,10 @@ class WmsSource(Source):
                 'host_name': hostName
             }
         }
+        if username and password:
+            credentials = encryptCredentials("{}:{}".format(
+                username, password))
+            minerva_metadata['wms_params']['credentials'] = credentials
         desc = 'wms source for  %s' % name
         return self.createSource(name, minerva_metadata, desc)
     createWmsSource.description = (

--- a/server/utility/minerva_utility.py
+++ b/server/utility/minerva_utility.py
@@ -16,7 +16,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 ###############################################################################
-
+from cryptography.fernet import Fernet
 from girder.utility.model_importer import ModelImporter
 
 from girder.plugins.minerva.constants import PluginSettings
@@ -126,3 +126,15 @@ def updateMinervaMetadata(item, minerva_metadata):
     item['meta']['minerva'] = minerva_metadata
     ModelImporter.model('item').setMetadata(item, item['meta'])
     return item['meta']['minerva']
+
+
+def decryptCredentials(credentials):
+    key = PluginSettings.CRYPTO_KEY
+    f = Fernet(key)
+    return f.decrypt(bytes(credentials))
+
+
+def encryptCredentials(credentials):
+    key = PluginSettings.CRYPTO_KEY
+    f = Fernet(key)
+    return f.encrypt(bytes(credentials))

--- a/web_external/js/views/body/MapPanel.js
+++ b/web_external/js/views/body/MapPanel.js
@@ -16,7 +16,6 @@ minerva.views.MapPanel = minerva.View.extend({
                     minervaMetadata.credentials;
         }
         var layerName = minervaMetadata.type_name;
-        // TODO: inclued projection in params ??
         var projection = 'EPSG:3857';
         layer.gcs(projection);
         layer.tileUrl(

--- a/web_external/js/views/body/MapPanel.js
+++ b/web_external/js/views/body/MapPanel.js
@@ -11,6 +11,10 @@ minerva.views.MapPanel = minerva.View.extend({
     _specifyWmsDatasetLayer: function (dataset, layer) {
         var minervaMetadata = dataset.getMinervaMetadata();
         var baseUrl = minervaMetadata.base_url;
+        if (minervaMetadata.hasOwnProperty('credentials')) {
+            baseUrl = '/wms_proxy/' + encodeURIComponent(baseUrl) + '/' +
+                    minervaMetadata.credentials;
+        }
         var layerName = minervaMetadata.type_name;
         // TODO: inclued projection in params ??
         var projection = 'EPSG:3857';
@@ -27,7 +31,7 @@ minerva.views.MapPanel = minerva.View.extend({
                 var bbox_mercator = sw.x + ',' + sw.y + ',' + ne.x + ',' + ne.y;
                 var params = {
                     SERVICE: 'WMS',
-                    VERSION: '1.3.0',
+                    VERSION: '1.1.1',
                     REQUEST: 'GetMap',
                     LAYERS: layerName,
                     STYLES: '',


### PR DESCRIPTION
If  a username & password are entered in for a WMS Source, they will be encrypted and saved in the metadata for the source and it's child datasets.  The credentials will then be decrypted, passed on to a proxy, and added to headers of GetMap requests.

A sample encryption key was added to server/constants.py but should be customized for a production instance.

