### PR TITLE
Correct usage of girderModal

### DIFF
--- a/web_external/js/views/widgets/WmsLayersListWidget.js
+++ b/web_external/js/views/widgets/WmsLayersListWidget.js
@@ -37,9 +37,10 @@ minerva.views.WmsLayersListWidget = minerva.View.extend({
     },
 
     render: function () {
-        var modal = this.$el.html(minerva.templates.wmsLayersListWidget({ layers: this.layers }));
+        var modal = this.$el.html(minerva.templates.wmsLayersListWidget({
+            layers: this.layers
+        })).girderModal(this);
         modal.trigger($.Event('ready.girder.modal', {relatedTarget: modal}));
-        this.$el.modal('show');
         return this;
     },
 


### PR DESCRIPTION
Fixes #121.

Steps to reproduce issue:
- Add a new WMS source
- Add a dataset from the source
- Add another WMS source
- Add a dataset from the second WMS source

Also check that adding a dataset from a source, then adding the same or different dataset from the same source doesn't add multiple/duplicate datasets.


It was my fault before @mbertrand , I wasn't using the right magic to invoke modal dialogs.  We probably need to ensure we are doing this everywhere.
