### PR TITLE
Refactor client side geojson dataset

### DIFF
--- a/plugin.cmake
+++ b/plugin.cmake
@@ -23,6 +23,7 @@ add_python_test(s3_dataset PLUGIN minerva)
 add_python_test(import_analyses PLUGIN minerva)
 add_python_test(contour_analysis PLUGIN minerva)
 add_python_test(wms PLUGIN minerva)
+add_python_test(geojson PLUGIN minerva)
 
 
 set(SPARK_TEST_MASTER_URL  "" CACHE STRING "Spark master URL")

--- a/plugin_tests/geojson_test.py
+++ b/plugin_tests/geojson_test.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+###############################################################################
+#  Copyright Kitware Inc.
+#
+#  Licensed under the Apache License, Version 2.0 ( the "License" );
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+###############################################################################
+
+import os
+
+# Need to set the environment variable before importing girder
+os.environ['GIRDER_PORT'] = os.environ.get('GIRDER_TEST_PORT', '20200')  # noqa
+
+from tests import base
+
+
+def setUpModule():
+    """
+    Enable the minerva plugin and start the server.
+    """
+    base.enabledPlugins.append('jobs')
+    base.enabledPlugins.append('romanesco')
+    base.enabledPlugins.append('gravatar')
+    base.enabledPlugins.append('minerva')
+    base.startServer(False)
+
+
+def tearDownModule():
+    """
+    Stop the server.
+    """
+    base.stopServer()
+
+
+class GeojsonTestCase(base.TestCase):
+
+    """
+    Tests of the minerva geojson API endpoints.
+    """
+
+    def setUp(self):
+        """
+        Set up the test case with  a user
+        """
+        super(GeojsonTestCase, self).setUp()
+
+        self._user = self.model('user').createUser(
+            'minervauser', 'password', 'minerva', 'user',
+            'minervauser@example.com')
+
+    def testCreateGeojsonDataset(self):
+        """
+        Test the minerva Geojson Dataset create API endpoint.
+        """
+
+        # Create the dataset folder.
+
+        path = '/minerva_dataset/folder'
+        params = {
+            'userId': self._user['_id'],
+        }
+        response = self.request(path=path, method='POST', params=params, user=self._user)
+        self.assertStatusOk(response)
+        datasetFolder = response.json['folder']
+        datasetParentId = datasetFolder['parentId']
+
+        # Create an item in the dataset parent folder.
+
+        params = {
+            'name': 'misplaced_item',
+            'folderId': datasetParentId
+        }
+        response = self.request(path='/item', method='POST', params=params, user=self._user)
+        self.assertStatusOk(response)
+        misplacedItemId = response.json['_id']
+
+        # Attempt to create a geojson dataset in the wrong folder.
+
+        path = '/minerva_dataset_geojson'
+        params = {
+            'itemId': misplacedItemId
+        }
+        response = self.request(path=path, method='POST', params=params, user=self._user)
+        self.assertStatus(response, 400)
+
+
+
+        # Helper function to create an item and upload a file on disk.
+
+        def createItemFromFile(datasetFolderId, itemName, itemFile):
+            # create the item
+            params = {
+                'name': itemName,
+                'folderId': datasetFolderId
+            }
+            response = self.request(path='/item', method='POST', params=params, user=self._user)
+            self.assertStatusOk(response)
+            itemId = response.json['_id']
+
+            filename = itemFile['name']
+            filepath = itemFile['path']
+            mimeType = itemFile['mimeType']
+            sizeBytes = os.stat(filepath).st_size
+
+            # create the file
+            response = self.request(
+                path='/file',
+                method='POST',
+                user=self._user,
+                params={
+                    'parentType': 'item',
+                    'parentId': itemId,
+                    'name': filename,
+                    'size': sizeBytes,
+                    'mimeType': mimeType
+                }
+            )
+            self.assertStatusOk(response)
+            uploadId = response.json['_id']
+
+            # upload the file contents
+            with open(filepath, 'rb') as file:
+                filedata = file.read()
+
+            response = self.multipartRequest(
+                path='/file/chunk',
+                user=self._user,
+                fields=[('offset', 0), ('uploadId', uploadId)],
+                files=[('chunk', filename, filedata)]
+            )
+            self.assertStatusOk(response)
+
+            return itemId
+
+
+        # Create an item in the dataset folder without a json or geojson ext.
+
+        pluginTestDir = os.path.dirname(os.path.realpath(__file__))
+
+        csvFile = {
+            'name': 'points.csv',
+            'path': os.path.join(pluginTestDir, 'data', 'points.csv'),
+            'mimeType': 'application/csv'
+        }
+        csvItemId = createItemFromFile(datasetFolder['_id'], 'csvItem', csvFile)
+
+        path = '/minerva_dataset_geojson'
+        params = {
+            'itemId': csvItemId
+        }
+        response = self.request(path=path, method='POST', params=params, user=self._user)
+        self.assertStatus(response, 400)
+
+        # Create a geojson dataset from a json file item.
+
+        jsonFile = {
+            'name': 'twopoints.json',
+            'path': os.path.join(pluginTestDir, 'data', 'twopoints.json'),
+            'mimeType': 'application/json'
+        }
+        jsonItemId = createItemFromFile(datasetFolder['_id'], 'jsonItem', jsonFile)
+
+        path = '/minerva_dataset_geojson'
+        params = {
+            'itemId': jsonItemId
+        }
+        response = self.request(path=path, method='POST', params=params, user=self._user)
+        self.assertStatusOk(response)
+        # Ensure this is an item and not just minerva metadata.
+        self.assertHasKeys(response.json, ['baseParentType'])
+        # Ensure the minerva metadata is correct.
+        self.assertHasKeys(response.json['meta']['minerva'], ['geojson_file', 'dataset_type', 'original_type', 'original_files'])
+        self.assertEquals(response.json['meta']['minerva']['dataset_type'], 'geojson')
+        self.assertEquals(response.json['meta']['minerva']['original_type'], 'geojson')
+
+        # Create a geojson dataset from a geojson file item.
+
+        geojsonFile = {
+            'name': 'states.geojson',
+            'path': os.path.join(pluginTestDir, 'data', 'states.geojson'),
+            'mimeType': 'application/vnd.geo+json'
+        }
+        geojsonItemId = createItemFromFile(datasetFolder['_id'], 'geojsonItem', geojsonFile)
+
+        path = '/minerva_dataset_geojson'
+        params = {
+            'itemId': geojsonItemId
+        }
+        response = self.request(path=path, method='POST', params=params, user=self._user)
+        self.assertStatusOk(response)
+        # Ensure this is an item and not just minerva metadata.
+        self.assertHasKeys(response.json, ['baseParentType'])
+        # Ensure the minerva metadata is correct.
+        self.assertHasKeys(response.json['meta']['minerva'], ['geojson_file', 'dataset_type', 'original_type', 'original_files'])
+        self.assertEquals(response.json['meta']['minerva']['dataset_type'], 'geojson')
+        self.assertEquals(response.json['meta']['minerva']['original_type'], 'geojson')

--- a/server/loader.py
+++ b/server/loader.py
@@ -28,7 +28,7 @@ from girder.utility.model_importer import ModelImporter
 
 from girder.plugins.minerva.rest import \
         analysis, dataset, s3_dataset, session, shapefile, geocode, source, \
-        wms_dataset, wms_source
+        wms_dataset, wms_source, geojson_dataset
 from girder.plugins.minerva.constants import PluginSettings
 
 
@@ -192,4 +192,5 @@ def load(info):
     info['apiRoot'].minerva_source = source.Source()
     info['apiRoot'].minerva_source_wms = wms_source.WmsSource()
     info['apiRoot'].minerva_dataset_wms = wms_dataset.WmsDataset()
+    info['apiRoot'].minerva_dataset_geojson = geojson_dataset.GeojsonDataset()
     info['serverRoot'].wms_proxy = WmsProxy()

--- a/server/rest/geojson_dataset.py
+++ b/server/rest/geojson_dataset.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+###############################################################################
+#  Copyright Kitware Inc.
+#
+#  Licensed under the Apache License, Version 2.0 ( the "License" );
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+###############################################################################
+
+from girder.api import access
+from girder.api.describe import Description
+from girder.api.rest import loadmodel, RestException
+from girder.constants import AccessType
+
+from girder.plugins.minerva.rest.dataset import Dataset
+
+from girder.plugins.minerva.utility.minerva_utility import findDatasetFolder, \
+    updateMinervaMetadata
+
+
+class GeojsonDataset(Dataset):
+    def __init__(self):
+        self.resourceName = 'minerva_dataset_geojson'
+        self.route('POST', (), self.createGeojsonDataset)
+
+    @access.public
+    @loadmodel(map={'itemId': 'item'}, model='item',
+               level=AccessType.WRITE)
+    def createGeojsonDataset(self, item, params):
+        # TESTS:
+        # create one with an item in the wrong folder
+        # create one with an item without a geojson
+        user = self.getCurrentUser()
+        folder = findDatasetFolder(user, user, create=True)
+        if folder is None:
+            raise RestException('User has no Minerva Dataset folder.')
+        if folder['_id'] != item['folderId']:
+            raise RestException("Items need to be in user's Minerva Dataset " +
+                                "folder.")
+        minerva_metadata = {
+            'original_type': 'geojson',
+            'dataset_type': 'geojson',
+        }
+        # Use the first geojson or json file found as the dataset.
+        for file in self.model('item').childFiles(item=item, limit=0):
+            if 'geojson' in file['exts'] or 'json' in file['exts']:
+                minerva_metadata['original_files'] = [{
+                    'name': file['name'], '_id': file['_id']}]
+                minerva_metadata['geojson_file'] = {
+                    'name': file['name'], '_id': file['_id']}
+                break
+        if 'geojson_file' not in minerva_metadata:
+            raise RestException('Item contains no geojson file.')
+        updateMinervaMetadata(item, minerva_metadata)
+        return item
+    createGeojsonDataset.description = (
+        Description('Create a Geojson Dataset from an Item.')
+        .responseClass('Item')
+        .param('itemId', 'Item ID of the existing Geojson Item', required=True)
+        .errorResponse('ID was invalid.')
+        .errorResponse('Write permission denied on the Item.', 403))

--- a/server/rest/geojson_dataset.py
+++ b/server/rest/geojson_dataset.py
@@ -33,13 +33,10 @@ class GeojsonDataset(Dataset):
         self.resourceName = 'minerva_dataset_geojson'
         self.route('POST', (), self.createGeojsonDataset)
 
-    @access.public
+    @access.user
     @loadmodel(map={'itemId': 'item'}, model='item',
                level=AccessType.WRITE)
     def createGeojsonDataset(self, item, params):
-        # TESTS:
-        # create one with an item in the wrong folder
-        # create one with an item without a geojson
         user = self.getCurrentUser()
         folder = findDatasetFolder(user, user, create=True)
         if folder is None:

--- a/server/rest/wms_dataset.py
+++ b/server/rest/wms_dataset.py
@@ -80,7 +80,7 @@ class WmsDataset(Dataset):
     createWmsDataset.description = (
         Description('Create a WMS Dataset from a WMS Source.')
         .responseClass('Item')
-        .param('name', 'The name of the wms source', required=True)
+        .param('name', 'The name of the wms dataset', required=True)
         .param('wmsSourceId', 'Item ID of the WMS Source', required=True)
         .param('typeName', 'The type name of the WMS layer', required=True)
         .errorResponse('ID was invalid.')

--- a/web_external/js/collections/DatasetCollection.js
+++ b/web_external/js/collections/DatasetCollection.js
@@ -5,6 +5,8 @@ minerva.collections.DatasetCollection = minerva.collections.MinervaCollection.ex
         if (attrs.meta && ('minerva' in attrs.meta)) {
             if (attrs.meta.minerva.dataset_type === 'wms') {
                 return new minerva.models.WmsDatasetModel(attrs, options);
+            } else if (attrs.meta.minerva.dataset_type === 'geojson') {
+                return new minerva.models.GeojsonDatasetModel(attrs, options);
             } else if (attrs.meta.minerva.original_type === 's3') {
                 return new minerva.models.S3DatasetModel(attrs, options);
             }

--- a/web_external/js/models/DatasetModel.js
+++ b/web_external/js/models/DatasetModel.js
@@ -13,12 +13,9 @@ minerva.models.DatasetModel = minerva.models.MinervaModel.extend({
         // but to do that we would have to be persisting geoFileReader to the server
         // which would require some things being rearranged.
 
-        // For now we know that if original_type is 'json' its ACTUALLY contour json,
-        // and if its'geojson'  its actually geojson - and for now these are the only
-        // two renderable data types.
-        return this.getMinervaMetadata().original_type === 'json' ||
-            this.getMinervaMetadata().original_type === 'geojson' ||
-            this.getMinervaMetadata().original_type === 'shapefile';
+        // For now we know that if original_type is 'json' it's ACTUALLY contour json,
+        // which is the only renderable type of DatasetModel.
+        return this.getMinervaMetadata().original_type === 'json';
     },
 
     createDataset: function () {
@@ -318,21 +315,7 @@ minerva.models.DatasetModel = minerva.models.MinervaModel.extend({
     loadGeoJsonData: function () {
         if (this.geoJsonAvailable) {
             var minervaMeta = this.getMinervaMetadata();
-            if (minervaMeta.geojson_file) {
-                // just download from the endpoint
-                $.ajax({
-                    url: girder.apiRoot + '/file/' + minervaMeta.geojson_file._id + '/download',
-                    contentType: 'application/json',
-                    success: _.bind(function (data) {
-                        this.fileData = data;
-                        this.geoFileReader = 'jsonReader';
-                    }, this),
-                    complete: _.bind(function () {
-                        this.trigger('m:geoJsonDataLoaded', this.get('_id'));
-                        this.trigger('m:dataLoaded', this.get('_id'));
-                    }, this)
-                });
-            } else if (minervaMeta.original_type === 'mongo') {
+            if (minervaMeta.original_type === 'mongo') {
                 // TODO search params
                 // if mongo, we'll need to pass down some search params to a new
                 // endpoint that will pull out of mongo and convert into geojson

--- a/web_external/js/models/GeojsonDatasetModel.js
+++ b/web_external/js/models/GeojsonDatasetModel.js
@@ -1,0 +1,42 @@
+minerva.models.GeojsonDatasetModel = minerva.models.DatasetModel.extend({
+
+    isRenderable: function () {
+        return true;
+    },
+
+    createGeojsonDataset: function (params) {
+        girder.restRequest({
+            path: '/minerva_dataset_geojson',
+            type: 'POST',
+            data: params,
+            error: null // ignore default error behavior (validation may fail)
+        }).done(_.bind(function (resp) {
+            this.set(resp);
+            this.trigger('m:wmsDatasetAdded');
+        }, this)).error(_.bind(function (err) {
+            this.trigger('m:error', err);
+        }, this));
+
+        return this;
+    },
+
+    loadData: function () {
+        if (this.fileData) {
+            this.trigger('m:dataLoaded', this.get('_id'));
+        } else {
+            var minervaMeta = this.getMinervaMetadata();
+            // Download geojson file.
+            $.ajax({
+                url: girder.apiRoot + '/file/' + minervaMeta.geojson_file._id + '/download',
+                contentType: 'application/json',
+                success: _.bind(function (data) {
+                    this.fileData = data;
+                    this.geoFileReader = 'jsonReader';
+                }, this),
+                complete: _.bind(function () {
+                    this.trigger('m:dataLoaded', this.get('_id'));
+                }, this)
+            });
+        }
+    }
+});


### PR DESCRIPTION
Closing #124 as this PR includes and builds on that.

Fixes #99.  Fixes #100.

Here's how to test this, since this PR doesn't include fixing the full pathway of uploading a geojson and having it render, all through the Minerva web app.  

  * upload a local geojson file through the minerva web app, under the  dataset panel // add local file.  an example geojson is provided in [states.geojson](https://github.com/Kitware/minerva/blob/master/plugin_tests/data/states.geojson) in this repo, which has 3 US state outlines and capital cities as points
  * click on the `i` info icon next to the uploaded dataset, copy the `dataset_id` value
  * go to the Minerva web api page (assuming you run Minerva at localhost:8080, go to http://localhost:8080/api/, open the minerva_dataset_geojson POST endpoint, enter the dataset_id and execute
  * refresh the Minerva web app page, now if you click on the `i` icon next to the states.geojson dataset you should see (modulo the _ids being different)
```
{
    "dataset_type": "geojson",
    "geojson_file": {
        "_id": "560aac120640fd0e29cda654",
        "name": "states.geojson"
    },
    "original_files": [
        {
            "_id": "560aac120640fd0e29cda654",
            "name": "states.geojson"
        }
    ],
    "original_type": "geojson"
}
```
  * now you can click the arrow which should display next to this dataset and you can render it


Following these directions exercises both the client side geojson dataset model and the server side create geojson dataset API endpoint.

![screen shot 2015-09-29 at 11 41 05 am](https://cloud.githubusercontent.com/assets/595023/10169429/02908604-669f-11e5-8c5c-cea80ecae6df.png)

