### PR TITLE
Minerva configuration file for encryption key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ before_install:
     - rm -rf girder
     - git clone https://github.com/girder/girder.git
     - mv Kitware/minerva girder/plugins
+    - cp girder/plugins/minerva/server/conf/minerva.dist.cfg girder/plugins/minerva/server/conf/minerva.local.cfg
 
     # clone romanesco
     - cd $HOME/build/girder/plugins

--- a/README.md
+++ b/README.md
@@ -46,9 +46,10 @@ sudo dnf install git gcc-c++ libffi-devel make python-devel python-pip freetype-
 
     grunt
 
-- change the encrypt_key value in Minerva's `minerva.dist.cfg` file, located in the server/conf directory.
-The key needs to be a 32 byte url-safe base-64 encoded string.  You can either replace the existing string
-with one of equal length, using letters and numbers, and ending with an '=', or generate one within python
+- copy the `minerva.dist.cfg` file, located in the server/conf directory, to `minerva.local.cfg` in that same directory.
+Any property in `minerva.local.cfg` will take precedent over any property with the same name in `minerva.dist.cfg`.
+Change the `encrypt_key` value in `minerva.local.cfg` file; the value should be a 32 byte url-safe base-64 encoded string.
+You can either replace the existing string with one of equal length, using letters and numbers, and ending with an '=', or generate one within python
 with the following code::
 
 ```

--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ sudo dnf install git gcc-c++ libffi-devel make python-devel python-pip freetype-
 
     grunt
 
+- change the encrypt_key value in Minerva's `minerva.dist.cfg` file, located in the server/conf directory.
+The key needs to be a 32 byte url-safe base-64 encoded string.  You can either replace the existing string
+with one of equal length, using letters and numbers, and ending with an '=', or generate one within python
+with the following code::
+
+```
+from cryptography.fernet import Fernet
+Fernet.generate_key()
+```
+
 - enable the Minerva plugin through the Girder Admin console
 - restart Girder through the Girder Admin console
 

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -16,8 +16,16 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 ###############################################################################
-
 import loader
+import os
+from girder.utility.config import _mergeConfig
+
+PACKAGE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+# Read the configuration files
+_cfgs = ('minerva.dist.cfg', 'minerva.local.cfg')
+for f in _cfgs:
+    _mergeConfig(os.path.join(PACKAGE_DIR, 'conf', f))
 
 def load(info):
     loader.load(info)

--- a/server/conf/.gitignore
+++ b/server/conf/.gitignore
@@ -1,0 +1,1 @@
+minerva.local.cfg

--- a/server/conf/minerva.dist.cfg
+++ b/server/conf/minerva.dist.cfg
@@ -1,0 +1,2 @@
+[auth]
+crypto_key: "CHANGEME-EykxwRhz0BKiF8-Frc0D1VtBUntKyTrcTk="

--- a/server/conf/minerva.dist.cfg
+++ b/server/conf/minerva.dist.cfg
@@ -1,2 +1,2 @@
-[auth]
+[minerva]
 crypto_key: "CHANGEME-EykxwRhz0BKiF8-Frc0D1VtBUntKyTrcTk="

--- a/server/constants.py
+++ b/server/constants.py
@@ -26,4 +26,3 @@ class PluginSettings():
     SESSION_FOLDER = 'session'
     GEOJSON_EXTENSION = '.geojson'
     SESSION_FILENAME = 'session.json'
-    CRYPTO_KEY = 'CHANGEME-EykxwRhz0BKiF8-Frc0D1VtBUntKyTrcTk='

--- a/server/loader.py
+++ b/server/loader.py
@@ -30,6 +30,7 @@ from girder.plugins.minerva.rest import \
         analysis, dataset, s3_dataset, session, shapefile, geocode, source, \
         wms_dataset, wms_source, geojson_dataset
 from girder.plugins.minerva.constants import PluginSettings
+from girder.plugins.minerva.utility.minerva_utility import decryptCredentials
 
 
 class CustomAppRoot(object):
@@ -145,11 +146,8 @@ class WmsProxy(object):
     exposed = True
 
     def GET(self, url, credentials, **params):
-        from cryptography.fernet import Fernet
-        key = PluginSettings.CRYPTO_KEY
-        f = Fernet(key)
-        credentials = 'Basic ' + b64encode(f.decrypt(bytes(credentials)))
-        headers = {'Authorization': credentials}
+        auth = 'Basic ' + b64encode(decryptCredentials(bytes(credentials)))
+        headers = {'Authorization': auth}
         r = requests.get(url, params=params, headers=headers)
         cherrypy.response.headers['Content-Type'] = r.headers['content-type']
         return r.content

--- a/server/utility/minerva_utility.py
+++ b/server/utility/minerva_utility.py
@@ -17,6 +17,7 @@
 #  limitations under the License.
 ###############################################################################
 from cryptography.fernet import Fernet
+from girder.utility import config
 from girder.utility.model_importer import ModelImporter
 
 from girder.plugins.minerva.constants import PluginSettings
@@ -129,12 +130,14 @@ def updateMinervaMetadata(item, minerva_metadata):
 
 
 def decryptCredentials(credentials):
-    key = PluginSettings.CRYPTO_KEY
+    cur_config = config.getConfig()
+    key = cur_config['auth']['crypto_key']
     f = Fernet(key)
     return f.decrypt(bytes(credentials))
 
 
 def encryptCredentials(credentials):
-    key = PluginSettings.CRYPTO_KEY
+    cur_config = config.getConfig()
+    key = cur_config['auth']['crypto_key']
     f = Fernet(key)
     return f.encrypt(bytes(credentials))

--- a/server/utility/minerva_utility.py
+++ b/server/utility/minerva_utility.py
@@ -131,13 +131,13 @@ def updateMinervaMetadata(item, minerva_metadata):
 
 def decryptCredentials(credentials):
     cur_config = config.getConfig()
-    key = cur_config['auth']['crypto_key']
+    key = cur_config['minerva']['crypto_key']
     f = Fernet(key)
     return f.decrypt(bytes(credentials))
 
 
 def encryptCredentials(credentials):
     cur_config = config.getConfig()
-    key = cur_config['auth']['crypto_key']
+    key = cur_config['minerva']['crypto_key']
     f = Fernet(key)
     return f.encrypt(bytes(credentials))


### PR DESCRIPTION
Created minerva configuration files (conf/minerva.dist.cfg, conf/minerva.local.cfg), moved the crypto_key setting out of constants.py into the minerva.dist.cfg file, and added code to read in the configuration.

Also removed some duplicate code from the WmsProxy class.

@mgrauer This PR addresses https://github.com/Kitware/minerva/issues/131