### PR TITLE
Bsve analysis update

### DIFF
--- a/server/jobs/bsve_search_worker.py
+++ b/server/jobs/bsve_search_worker.py
@@ -11,8 +11,7 @@ from girder.utility.model_importer import ModelImporter
 from girder.plugins.jobs.constants import JobStatus
 from girder.plugins.minerva.utility.bsve.bsve_utility import BsveUtility
 from girder.plugins.minerva.utility.dataset_utility import \
-    jsonArrayHead
-
+    jsonArrayHead, GeoJsonMapper, jsonObjectReader
 
 import girder_client
 
@@ -87,6 +86,40 @@ def run(job):
 
         jsonRow = jsonArrayHead(humanFilepath, limit=1)[0]
         minerva_metadata['json_row'] = jsonRow
+
+        # Generate the geojson for this dataset and set
+        # dataset_type = geojson
+
+        geojsonFilename = 'search.geojson'
+        geojsonFilepath = os.path.join(tmpdir, geojsonFilename)
+
+        mapping = {
+            "dateKeypath": "",
+            "latitudeKeypath": "data.Latitude",
+            "longitudeKeypath": "data.Longitude"
+        }
+
+        geojsonMapper = GeoJsonMapper(objConverter=None, mapping=mapping)
+        objects = jsonObjectReader(humanFilepath)
+        geojsonMapper.mapToJsonFile(tmpdir, objects, geojsonFilepath)
+
+        client.uploadFileToItem(datasetId, geojsonFilepath)
+
+        minerva_metadata['mapper'] = mapping
+        minerva_metadata['dataset_type'] = 'geojson'
+
+        existing = file_model.findOne({
+            'itemId': dataset['_id'],
+            'name': geojsonFilename
+        })
+        if existing:
+            minerva_metadata['geojson_file'] = {
+                '_id': existing['_id'],
+                'name': geojsonFilename
+            }
+        else:
+            raise (Exception('Cannot find file %s in dataset %s' %
+                   (geojsonFilename, datasetId)))
 
         shutil.rmtree(tmpdir)
 

--- a/server/rest/s3_source.py
+++ b/server/rest/s3_source.py
@@ -38,7 +38,7 @@ class S3Source(Source):
         user = self.getCurrentUser()
         name = params['name']
         bucket = params['bucket'].strip()
-        prefix = params['prefix'].strip()
+        prefix = params.get('prefix', '').strip()
         access_key_id = params.get('accessKeyId', '').strip()
         secret = params.get('secret', '').strip()
         service = params.get('service', '').strip()

--- a/web_external/js/views/widgets/AddS3SourceWidget.js
+++ b/web_external/js/views/widgets/AddS3SourceWidget.js
@@ -22,11 +22,19 @@ minerva.views.AddS3SourceWidget = minerva.View.extend({
                 params.prefix = '/' + params.prefix;
             }
 
+            if (name.trim() === '' || bucket.trim() === '') {
+                this.$('.g-validation-failed-message').text('Source name and S3 bucket name are required');
+                return;
+            }
+
             var s3Source = new minerva.models.S3SourceModel();
             s3Source.on('m:sourceReceived', function () {
                 this.$el.modal('hide');
+                this.$('.g-validation-failed-message').text('');
                 // TODO: might need to be added to a new panel/data sources ?
                 girder.events.trigger('m:job.created');
+            }, this).on('m:error', function (msg) {
+                this.$('.g-validation-failed-message').text(msg.responseText);
             }, this).createSource(params);
         }
     },

--- a/web_external/js/views/widgets/AddS3SourceWidget.js
+++ b/web_external/js/views/widgets/AddS3SourceWidget.js
@@ -22,7 +22,7 @@ minerva.views.AddS3SourceWidget = minerva.View.extend({
                 params.prefix = '/' + params.prefix;
             }
 
-            if (name.trim() === '' || bucket.trim() === '') {
+            if (params.name.trim() === '' || params.bucket.trim() === '') {
                 this.$('.g-validation-failed-message').text('Source name and S3 bucket name are required');
                 return;
             }

--- a/web_external/js/views/widgets/ReadOnlyHierarchyWidget.js
+++ b/web_external/js/views/widgets/ReadOnlyHierarchyWidget.js
@@ -97,7 +97,7 @@ minerva.views.ReadOnlyHierarchyWidget = girder.views.HierarchyWidget.extend({
      * the checked menu state.
      */
     updateChecked: function () {
-        // do nothing
+        // No Op, the superclass requires an implementation.
     },
 
     getCheckedResources: function () {


### PR DESCRIPTION
I've based this on top of the S3 source refactor, and can rebase once that gets into master.

This pulls out and cleans up the bsve search analysis work from #143--that is, calling the bsve search API, getting the results as json, converting them to lat/long geojson points, and setting the dataset output to be geojson.

Also follows the path laid out in #145, in that it creates links to the dataset as output of the job, stored in the job's metadata's minerva namespace.

It further updates the tests to be in sync with the code.