### PR TITLE
Remove cdn client resources

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -283,9 +283,6 @@ module.exports = function (grunt) {
             }
         }
         dependencies.concat([
-            'http://cdn.datatables.net/1.10.7/js/jquery.dataTables.min.js',
-            'http://cdn.jsdelivr.net/momentjs/2.9.0/moment.min.js',
-            'http://cdn.jsdelivr.net/bootstrap.daterangepicker/1/daterangepicker.js',
             '/' + staticDir + '/papaparse.min.js',
             '/' + staticDir + '/jsonpath.min.js'
         ]);
@@ -307,14 +304,11 @@ module.exports = function (grunt) {
         var cssFiles =  [
             // ?? href="//fonts.googleapis.com/css?family=Droid+Sans:400,700">
             '/' + rootStaticLibDir + '/bootstrap/css/bootstrap.min.css',
-            'http://cdn.jsdelivr.net/bootstrap/3.3.2/css/bootstrap.css',
             '/' + rootStaticLibDir + '/fontello/css/fontello.css',
             '/' + rootStaticLibDir + '/fontello/css/animation.css',
             '/' + staticDir + '/jquery.gridster.min.css',
             '/' + staticDir + '/jquery-ui.min.css',
-            '/' + rootStaticDir + '/app.min.css',
-            'http://cdn.datatables.net/1.10.7/css/jquery.dataTables.css',
-            'http://cdn.jsdelivr.net/bootstrap.daterangepicker/1/daterangepicker-bs3.css'
+            '/' + rootStaticDir + '/app.min.css'
         ];
         // if any plugin dependencies have css, add them
         for (i = 0; i < pluginDependencies.length; i = i + 1) {

--- a/server/minerva.mako
+++ b/server/minerva.mako
@@ -6,7 +6,6 @@
           href="//fonts.googleapis.com/css?family=Droid+Sans:400,700">
     <link rel="stylesheet"
           href="${staticRoot}/lib/bootstrap/css/bootstrap.min.css">
-    <link rel="stylesheet" type="text/css" href="////cdn.jsdelivr.net/bootstrap/3.3.2/css/bootstrap.css"/>
     <link rel="stylesheet"
           href="${staticRoot}/lib/fontello/css/fontello.css">
     <link rel="stylesheet"
@@ -25,10 +24,6 @@
             href="${staticRoot}/built/plugins/${plugin}/plugin.min.css">
         % endif
     % endfor
-    <link rel="stylesheet"
-          href="http:////cdn.datatables.net/1.10.7/css/jquery.dataTables.css">
-    <link rel="stylesheet"
-          href="http:////cdn.jsdelivr.net/bootstrap.daterangepicker/1/daterangepicker-bs3.css">
     <link rel="stylesheet"
           href="${staticRoot}/built/plugins/minerva/minerva.min.css">
     <link rel="icon"
@@ -56,9 +51,6 @@
             <script src="${staticRoot}/built/plugins/${plugin}/plugin.min.js"></script>
         % endif
     % endfor
-    <script src="http://cdn.datatables.net/1.10.7/js/jquery.dataTables.min.js"></script>
-    <script src="http://cdn.jsdelivr.net/momentjs/2.9.0/moment.min.js"></script>
-    <script src="http://cdn.jsdelivr.net/bootstrap.daterangepicker/1/daterangepicker.js"></script>
     <script src="${staticRoot}/built/plugins/minerva/papaparse.min.js"></script>
     <script src="${staticRoot}/built/plugins/minerva/jsonpath.min.js"></script>
     <script src="${staticRoot}/built/plugins/minerva/minerva.min.js"></script>

--- a/web_external/js/views/widgets/KeymapWidget.js
+++ b/web_external/js/views/widgets/KeymapWidget.js
@@ -9,8 +9,7 @@ minerva.views.KeymapWidget = minerva.View.extend({
 
             var mapper = {
                 longitudeKeypath: this.$('#m-longitude-mapper').val(),
-                latitudeKeypath: this.$('#m-latitude-mapper').val(),
-                dateKeypath: this.$('#m-date-range-filter-mapper').val()
+                latitudeKeypath: this.$('#m-latitude-mapper').val()
             };
 
             // validate columns, be sure they aren't equal
@@ -53,9 +52,6 @@ minerva.views.KeymapWidget = minerva.View.extend({
             var longExampleVal = jsonPath.eval(this.jsonrowData, jsonpathLong); // jshint ignore:line
             this.$('#m-longitude-example-value').val(longExampleVal);
         },
-        'change #m-date-range-filter-mapper': function () {
-            this.populateDateRangeFilter();
-        },
         'click .hide-keymap-preview': function () {
             this.$('.hide-keymap-preview').hide();
             this.$('.jsonrowData').hide();
@@ -79,79 +75,22 @@ minerva.views.KeymapWidget = minerva.View.extend({
         this.jsonrowData = this.dataset.getJsonRowData();
     },
 
-    populateDateRangeFilter: function () {
-        var jsonpathDate = this.$('#m-date-range-filter-mapper').val();
-        if (jsonpathDate) {
-            var dateExampleVal = jsonPath.eval(this.jsonrowData, jsonpathDate); // jshint ignore:line
-            this.$('#m-date-example-value').val(dateExampleVal);
-            if (dateExampleVal.length > 0) {
-                // TODO
-                // probably want a button to trigger this
-
-                var secondsSinceEpochToDateString = function (seconds) {
-                    var d = new Date(seconds * 1000);
-                    var dateString = d.getUTCFullYear() + '-' +
-                        ('0' + (d.getUTCMonth() + 1)).slice(-2) + '-' +
-                        ('0' + d.getUTCDate()).slice(-2) + ' ' +
-                        ('0' + d.getUTCHours()).slice(-2) + ':' +
-                        ('0' + d.getUTCMinutes()).slice(-2) + ':' +
-                        ('0' + d.getUTCSeconds()).slice(-2);
-                    return dateString;
-                };
-
-                this.dataset.on('m:externalMongoLimitsGot', function () {
-                    var jsonpathDate = this.$('#m-date-range-filter-mapper').val();
-                    var fields = this.dataset.metadata().mongo_fields;
-                    var fieldLimits = fields[jsonpathDate];
-                    // fieldLimits are epoch time, convert to date
-                    this.startTime = fieldLimits.min;
-                    this.endTime = fieldLimits.max;
-                    var startTimeString = secondsSinceEpochToDateString(this.startTime);
-                    var endTimeString = secondsSinceEpochToDateString(this.endTime);
-                    this.$('#m-date-range-filter').prop('disabled', false);
-                    this.$('#m-date-range-filter').val(startTimeString + ' - ' + endTimeString);
-                    this.$('#m-date-range-filter').daterangepicker({
-                        timePicker: true,
-                        format: 'YYYY-MM-DD H:mm:s',
-                        timePickerIncrement: 30,
-                        timePicker12Hour: false,
-                        minDate: startTimeString,
-                        maxDate: endTimeString,
-                        timePickerSeconds: false
-                    });
-                    this.$('#m-date-range-filter').on('apply.daterangepicker', _.bind(function (ev, picker) {
-                        // HACK super ugly convert to GMT - 4
-                        this.startTime = (Date.parse(picker.startDate._d.toISOString()) / 1000) - (4 * 3600);
-                        this.endTime = (Date.parse(picker.endDate._d.toISOString()) / 1000) - (4 * 3600);
-                    }, this));
-                }, this);
-                this.dataset.getExternalMongoLimits(jsonpathDate);
-            } else {
-                this.$('#m-date-range-filter').val('');
-            }
-        }
-    },
-
     render: function () {
         var longitudeKeypath = null,
             latitudeKeypath = null,
-            dateKeypath = null,
             latExampleVal = null,
             longExampleVal = null,
             dateExampleVal = null;
         if (!this.create) {
             longitudeKeypath = this.minervaMetadata.mapper.longitudeKeypath;
             latitudeKeypath = this.minervaMetadata.mapper.latitudeKeypath;
-            dateKeypath = this.minervaMetadata.mapper.dateKeypath;
             latExampleVal = jsonPath.eval(this.jsonrowData, latitudeKeypath); // jshint ignore:line
             longExampleVal = jsonPath.eval(this.jsonrowData, longitudeKeypath); // jshint ignore:line
-            dateExampleVal = jsonPath.eval(this.jsonrowData, dateKeypath); // jshint ignore:line
         }
         var modal = this.$el.html(minerva.templates.keymapWidget({
             create: this.create,
             longitudeKeypath: longitudeKeypath,
             latitudeKeypath: latitudeKeypath,
-            dateKeypath: dateKeypath,
             latExampleVal: latExampleVal,
             longExampleVal: longExampleVal,
             dateExampleVal: dateExampleVal
@@ -159,7 +98,6 @@ minerva.views.KeymapWidget = minerva.View.extend({
         }).on('hidden.bs.modal', function () {
         }).on('ready.girder.modal', _.bind(function () {
             this.$('#jsonrow-preview').text(JSON.stringify(this.jsonrowData, null, 4));
-            this.populateDateRangeFilter();
         }, this));
         modal.trigger($.Event('ready.girder.modal', {relatedTarget: modal}));
 


### PR DESCRIPTION
At first this was intended to fix up the cdn resources that were hard-coded to http.  @jbeezley pointed out how this was a problem when Minerva was served from https, the browser would block the mixed content.  PTAL.

In looking at those resources, I realized we aren't using any of them anyway and they can be removed.

@essamjoubori When we decide on a table library we want to bring in, we can add it in then.  Datatables is packaged for bower and npm, so that should be easy if we go with it.