### PR TITLE
Add numpy to the list of python dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ ijson==2.2.0
 geopy==1.10.0
 owslib==0.9.1
 cryptography==1.1.0
+numpy==1.10.1


### PR DESCRIPTION
We use numpy explicitly in a couple of places, and it is no longer installed via `gaia`.