### PR TITLE
Proxy non-auth wms

### DIFF
--- a/server/loader.py
+++ b/server/loader.py
@@ -35,10 +35,15 @@ from girder.plugins.minerva.utility.minerva_utility import decryptCredentials
 class WmsProxy(object):
     exposed = True
 
-    def GET(self, url, credentials, **params):
-        auth = 'Basic ' + b64encode(decryptCredentials(bytes(credentials)))
-        headers = {'Authorization': auth}
-        r = requests.get(url, params=params, headers=headers)
+    def GET(self, url, **params):
+        if 'minerva_credentials' in params:
+            creds = params['minerva_credentials']
+            del params['minerva_credentials']
+            auth = 'Basic ' + b64encode(decryptCredentials(bytes(creds)))
+            headers = {'Authorization': auth}
+            r = requests.get(url, params=params, headers=headers)
+        else:
+            r = requests.get(url, params=params)
         cherrypy.response.headers['Content-Type'] = r.headers['content-type']
         return r.content
 

--- a/web_external/js/views/body/MapPanel.js
+++ b/web_external/js/views/body/MapPanel.js
@@ -29,11 +29,7 @@ minerva.views.MapPanel = minerva.views.Panel.extend({
     _specifyWmsDatasetLayer: function (dataset, layer) {
         var minervaMetadata = dataset.metadata();
         layer.layerName = minervaMetadata.type_name;
-        layer.baseUrl = minervaMetadata.base_url;
-        if (minervaMetadata.hasOwnProperty('credentials')) {
-            layer.baseUrl = '/wms_proxy/' + encodeURIComponent(layer.baseUrl) +
-                    '/' + minervaMetadata.credentials;
-        }
+        layer.baseUrl = '/wms_proxy/' + encodeURIComponent(minervaMetadata.base_url);
         var projection = 'EPSG:3857';
         layer.gcs(projection);
         layer.tileUrl(
@@ -60,6 +56,9 @@ minerva.views.MapPanel = minerva.views.Panel.extend({
                     SRS: projection,
                     TILED: true
                 };
+                if (minervaMetadata.hasOwnProperty('credentials')) {
+                    params.minerva_credentials = minervaMetadata.credentials;
+                }
                 return layer.baseUrl + '?' + $.param(params);
             }
         );


### PR DESCRIPTION
Ready for review.  Maybe @mbertrand  or @jbeezley can take a look?

This proxies non authenticated wms layers through Girder as well as authenticated layers.  This change allows us to control the scheme wms resources are served through, so that we don't serve `http` wms resources that are out of our control when Minerva is served from `https`, since the browser won't display the mixed `http` content in this case.