### PR TITLE
Fix incompatibility with GeoJS 0.6 in WMS layers

### DIFF
--- a/web_external/js/views/widgets/WMSFeatureInfoWidget.js
+++ b/web_external/js/views/widgets/WMSFeatureInfoWidget.js
@@ -73,17 +73,12 @@ minerva.views.WmsFeatureInfoWidget = minerva.View.extend({
     getUrl: function (layer_idx, coord) {
 
         var pnt = this.map.gcsToDisplay(coord);
-        var mapBounds = this.map.bounds();
+        var mapBounds = this.map.bounds(undefined, 'EPSG:3857');
 
-        var ne = mapBounds.upperRight;
-        var sw = mapBounds.lowerLeft;
-
-        var neMerc = geo.mercator.ll2m(ne.x, ne.y);
-        var swMerc = geo.mercator.ll2m(sw.x, sw.y);
-        if (swMerc.x > neMerc.x) {
-            neMerc.x = 20037508.34 + (20037508.34 - neMerc.x);
+        if (mapBounds.left > mapBounds.right) {
+            mapBounds.right = 20037508.34 + (20037508.34 - mapBounds.right);
         }
-        var bbox = swMerc.x + ',' + swMerc.y + ',' + neMerc.x + ',' + neMerc.y;
+        var bbox = mapBounds.left + ',' + mapBounds.bottom + ',' + mapBounds.right + ',' + mapBounds.top;
 
         var rUrl = this.layers[layer_idx].baseUrl + '?' + this.fixedParams;
         rUrl += '&version=' + this.version;

--- a/web_external/js/views/widgets/WMSFeatureInfoWidget.js
+++ b/web_external/js/views/widgets/WMSFeatureInfoWidget.js
@@ -73,9 +73,11 @@ minerva.views.WmsFeatureInfoWidget = minerva.View.extend({
     getUrl: function (layer_idx, coord) {
 
         var pnt = this.map.gcsToDisplay(coord);
+        // Spherical Mercator projection.
         var mapBounds = this.map.bounds(undefined, 'EPSG:3857');
 
         if (mapBounds.left > mapBounds.right) {
+            // 20037508.34 is the maximum extent of the Spherical Mercator projection.
             mapBounds.right = 20037508.34 + (20037508.34 - mapBounds.right);
         }
         var bbox = mapBounds.left + ',' + mapBounds.bottom + ',' + mapBounds.right + ',' + mapBounds.top;


### PR DESCRIPTION
Fixes #266, but the feature still doesn't work for me.  There are no errors raised in the console, instead the WMS server responds with a message like this:
```xml
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<!DOCTYPE ServiceExceptionReport SYSTEM "http://geodata.epidemico.com/geoserver/schemas/wms/1.1.1/WMS_exception_1_1_1.dtd">
<ServiceExceptionReport version="1.1.1" > 
<ServiceException code="LayerNotDefined" locator="layers">
      Could not find layer geonode:CHN_ppp_v2c_2010_UNadj_tiled
</ServiceException>
</ServiceExceptionReport>
```

The name is correct in the request, so there could be credentials problem in proxy component.  It is possible there is something incorrect in my test database.