### PR TITLE
Fix overly general event selector

### DIFF
--- a/web_external/js/views/body/Panel.js
+++ b/web_external/js/views/body/Panel.js
@@ -1,9 +1,9 @@
 minerva.views.Panel = minerva.View.extend({
     /**
-     * The panel view isn't meant to be instantiated on it's own.
+     * The panel view isn't meant to be instantiated on its own.
      **/
     events: {
-        'click .icon-cancel': 'removePanel',
+        'click .m-remove-panel': 'removePanel',
         'show.bs.collapse': 'expandPanel',
         'hide.bs.collapse': 'collapsePanel'
     },
@@ -26,12 +26,15 @@ minerva.views.Panel = minerva.View.extend({
      * enables the save button.
      **/
     removePanel: function () {
-        if (confirm('Are you sure you want to remove this panel?')) {
-            this.getSessionView().disablePanel(this.el.id);
-            this.getSessionView()._enableSave();
-            this.remove();
-            minerva.View.prototype.remove.call(this);
-        }
+        girder.confirm({
+            text: 'Are you sure you want to remove this panel?',
+            confirmCallback: _.bind(function () {
+                this.getSessionView().disablePanel(this.el.id);
+                this.getSessionView()._enableSave();
+                this.remove();
+                minerva.View.prototype.remove.call(this);
+            }, this)
+        });
     },
 
     /**

--- a/web_external/templates/layout/panelMixins.jade
+++ b/web_external/templates/layout/panelMixins.jade
@@ -6,7 +6,7 @@ mixin panel-title(title, panelId)
       i(class='icon-up-open',
         data-toggle='collapse',
         data-target='##{panelId} > .m-panel-content')
-      i(class='icon-cancel')
+      i(class='icon-cancel m-remove-panel')
 
 
 mixin panel-content(cls)


### PR DESCRIPTION
This fixes an issue where if the user had an icon-cancel in one of their panels it could also trigger the panel removal.