### PR TITLE
[WIP] Move datapanel view logic to view

### DIFF
--- a/web_external/js/views/body/DataPanel.js
+++ b/web_external/js/views/body/DataPanel.js
@@ -164,13 +164,21 @@ minerva.views.DataPanel = minerva.views.Panel.extend({
         minerva.views.Panel.prototype.initialize.apply(this);
     },
 
-    render: function () {
+    /**
+     * Render the DatasetPanel view.
+     */
+     render: function () {
         var datasets = _.filter(this.collection.models, function (dataset) {
             return dataset.metadata();
         });
 
-        // Utility function to control dataset display name.
-        var getDisplayName = _.bind(function (dataset) {
+        /**
+         * Utility function to control dataset display name.
+         *
+         * @param {dataset} dataset the dataset model
+         * @returns {string} display name for the passed in dataset.
+         */
+         var getDisplayName = _.bind(function (dataset) {
             var name = dataset.get('name');
             if (name.length > this.DATASET_NAME_LENGTH) {
                 name = name.slice(0, this.DATASET_NAME_LENGTH) + "...";
@@ -178,8 +186,15 @@ minerva.views.DataPanel = minerva.views.Panel.extend({
             return name;
         }, this);
 
-        // Utility function to display event classes for visualization icon.
-        var getGeoRenderingClasses = _.bind(function (dataset) {
+        /**
+         * Utility function to display event classes for visualization icon, depending
+         * on the current state of the dataset.
+         *
+         * @param {dataset} dataset the dataset model
+         * @returns {string|false} classes for the visualization icon to render
+         * the dataset in the map, or false if the dataset cannot be rendered in the map.
+         */
+         var getGeoRenderingClasses = _.bind(function (dataset) {
             if (dataset.isGeoRenderable()) {
                 var classes =  dataset.get('displayed') ? 'm-icon-disabled m-dataset-in-session' : 'm-icon-enabled m-add-dataset-to-session';
                 return classes;
@@ -188,16 +203,44 @@ minerva.views.DataPanel = minerva.views.Panel.extend({
             }
         }, this);
 
-        // Utility function to display classes for delete icon.
-        var getDatasetDeleteClasses = _.bind(function (dataset) {
+        /**
+         * Utility function to display event classes for delete icon, depending
+         * on the current state of the dataset.
+         *
+         * @param {dataset} dataset the dataset model
+         * @returns {string|false} classes for the delete icon,
+         * or false if the dataset cannot be rendered in the map.
+         */
+         var getDatasetDeleteClasses = _.bind(function (dataset) {
             return dataset.get('displayed') ? 'm-icon-disabled m-dataset-in-session' : 'm-icon-enabled m-delete-dataset';
+        }, this);
+
+        /**
+         * Utility function to display event classes for map rendering config icon, depending
+         * on the current state of the dataset.
+         *
+         * @param {dataset} dataset the dataset model
+         * @returns {string|false} classes for the map rendering config icon,
+         * or false if the dataset does not have the ability to have map rendering configured.
+         */
+        var getGeoRenderingConfigClasses = _.bind(function (dataset) {
+            var geoRenderType = dataset.getGeoRenderType()
+            if (geoRenderType !== null && geoRenderType !== 'wms') {
+              var classes = 'm-configure-geo-render';
+              classes += (dataset.get('displayed') ? ' m-icon-disabled' : ' m-icon-enabled');
+              classes += ((!dataset.get('displayed') && dataset.get('geoError')) ? ' m-geo-render-error' : '');
+              return classes;
+            } else {
+              return false;
+            }
         }, this);
 
         this.$el.html(minerva.templates.dataPanel({
             datasets: datasets,
             getDisplayName: getDisplayName,
             getGeoRenderingClasses: getGeoRenderingClasses,
-            getDatasetDeleteClasses: getDatasetDeleteClasses
+            getDatasetDeleteClasses: getDatasetDeleteClasses,
+            getGeoRenderingConfigClasses: getGeoRenderingConfigClasses
         }));
 
         // TODO pagination and search?

--- a/web_external/js/views/body/DataPanel.js
+++ b/web_external/js/views/body/DataPanel.js
@@ -5,7 +5,7 @@ minerva.views.DataPanel = minerva.views.Panel.extend({
         'click .m-upload-local': 'uploadDialog',
         'click .m-delete-dataset': 'deleteDatasetEvent',
         'click .csv-mapping': 'mapTableDataset',
-        'click .dataset-info': 'displayDatasetInfo',
+        'click .m-dataset-info': 'displayDatasetInfo',
         'click .m-configure-geo-render': 'configureGeoRender'
     },
 

--- a/web_external/js/views/body/DataPanel.js
+++ b/web_external/js/views/body/DataPanel.js
@@ -10,6 +10,11 @@ minerva.views.DataPanel = minerva.views.Panel.extend({
     },
 
     /**
+     * Length of dataset name prefix to display.
+     */
+    DATASET_NAME_LENGTH: 20,
+
+    /**
      * Display a modal dialog allowing configuration of GeoJs rendering
      * properties for the selected dataset.
      */
@@ -164,8 +169,18 @@ minerva.views.DataPanel = minerva.views.Panel.extend({
             return dataset.metadata();
         });
 
+        // Utility method to control dataset display name.
+        var getDisplayName = _.bind(function (dataset) {
+            var name = dataset.get('name');
+            if (name.length > this.DATASET_NAME_LENGTH) {
+                name = name.slice(0, this.DATASET_NAME_LENGTH) + "...";
+            }
+            return name;
+        }, this);
+
         this.$el.html(minerva.templates.dataPanel({
-            datasets: datasets
+            datasets: datasets,
+            getDisplayName: getDisplayName
         }));
 
         // TODO pagination and search?

--- a/web_external/js/views/body/DataPanel.js
+++ b/web_external/js/views/body/DataPanel.js
@@ -3,7 +3,7 @@ minerva.views.DataPanel = minerva.views.Panel.extend({
         // TODO namespace.
         'click .m-add-dataset-to-session': 'addDatasetToSessionEvent',
         'click .m-upload-local': 'uploadDialog',
-        'click .delete-dataset': 'deleteDatasetEvent',
+        'click .m-delete-dataset': 'deleteDatasetEvent',
         'click .csv-mapping': 'mapTableDataset',
         'click .dataset-info': 'displayDatasetInfo',
         'click .m-configure-geo-render': 'configureGeoRender'
@@ -188,10 +188,16 @@ minerva.views.DataPanel = minerva.views.Panel.extend({
             }
         }, this);
 
+        // Utility function to display classes for delete icon.
+        var getDatasetDeleteClasses = _.bind(function (dataset) {
+            return dataset.get('displayed') ? 'm-icon-disabled m-dataset-in-session' : 'm-icon-enabled m-delete-dataset';
+        }, this);
+
         this.$el.html(minerva.templates.dataPanel({
             datasets: datasets,
             getDisplayName: getDisplayName,
-            getGeoRenderingClasses: getGeoRenderingClasses
+            getGeoRenderingClasses: getGeoRenderingClasses,
+            getDatasetDeleteClasses: getDatasetDeleteClasses
         }));
 
         // TODO pagination and search?

--- a/web_external/js/views/body/DataPanel.js
+++ b/web_external/js/views/body/DataPanel.js
@@ -1,7 +1,7 @@
 minerva.views.DataPanel = minerva.views.Panel.extend({
     events: {
         // TODO namespace.
-        'click .add-dataset-to-session': 'addDatasetToSessionEvent',
+        'click .m-add-dataset-to-session': 'addDatasetToSessionEvent',
         'click .m-upload-local': 'uploadDialog',
         'click .delete-dataset': 'deleteDatasetEvent',
         'click .csv-mapping': 'mapTableDataset',
@@ -169,7 +169,7 @@ minerva.views.DataPanel = minerva.views.Panel.extend({
             return dataset.metadata();
         });
 
-        // Utility method to control dataset display name.
+        // Utility function to control dataset display name.
         var getDisplayName = _.bind(function (dataset) {
             var name = dataset.get('name');
             if (name.length > this.DATASET_NAME_LENGTH) {
@@ -178,9 +178,20 @@ minerva.views.DataPanel = minerva.views.Panel.extend({
             return name;
         }, this);
 
+        // Utility function to display event classes for visualization icon.
+        var getGeoRenderingClasses = _.bind(function (dataset) {
+            if (dataset.isGeoRenderable()) {
+                var classes =  dataset.get('displayed') ? 'm-icon-disabled m-dataset-in-session' : 'm-icon-enabled m-add-dataset-to-session';
+                return classes;
+            } else {
+              return false;
+            }
+        }, this);
+
         this.$el.html(minerva.templates.dataPanel({
             datasets: datasets,
-            getDisplayName: getDisplayName
+            getDisplayName: getDisplayName,
+            getGeoRenderingClasses: getGeoRenderingClasses
         }));
 
         // TODO pagination and search?

--- a/web_external/js/views/body/DataPanel.js
+++ b/web_external/js/views/body/DataPanel.js
@@ -160,8 +160,12 @@ minerva.views.DataPanel = minerva.views.Panel.extend({
     },
 
     render: function () {
+        var datasets = _.filter(this.collection.models, function (dataset) {
+            return dataset.metadata();
+        });
+
         this.$el.html(minerva.templates.dataPanel({
-            datasets: this.collection.models
+            datasets: datasets
         }));
 
         // TODO pagination and search?

--- a/web_external/js/views/body/DataPanel.js
+++ b/web_external/js/views/body/DataPanel.js
@@ -167,7 +167,7 @@ minerva.views.DataPanel = minerva.views.Panel.extend({
     /**
      * Render the DatasetPanel view.
      */
-     render: function () {
+    render: function () {
         var datasets = _.filter(this.collection.models, function (dataset) {
             return dataset.metadata();
         });
@@ -178,10 +178,10 @@ minerva.views.DataPanel = minerva.views.Panel.extend({
          * @param {dataset} dataset the dataset model
          * @returns {string} display name for the passed in dataset.
          */
-         var getDisplayName = _.bind(function (dataset) {
+        var getDisplayName = _.bind(function (dataset) {
             var name = dataset.get('name');
             if (name.length > this.DATASET_NAME_LENGTH) {
-                name = name.slice(0, this.DATASET_NAME_LENGTH) + "...";
+                name = name.slice(0, this.DATASET_NAME_LENGTH) + '...';
             }
             return name;
         }, this);
@@ -194,12 +194,12 @@ minerva.views.DataPanel = minerva.views.Panel.extend({
          * @returns {string|false} classes for the visualization icon to render
          * the dataset in the map, or false if the dataset cannot be rendered in the map.
          */
-         var getGeoRenderingClasses = _.bind(function (dataset) {
+        var getGeoRenderingClasses = _.bind(function (dataset) {
             if (dataset.isGeoRenderable()) {
                 var classes =  dataset.get('displayed') ? 'm-icon-disabled m-dataset-in-session' : 'm-icon-enabled m-add-dataset-to-session';
                 return classes;
             } else {
-              return false;
+                return false;
             }
         }, this);
 
@@ -211,7 +211,7 @@ minerva.views.DataPanel = minerva.views.Panel.extend({
          * @returns {string|false} classes for the delete icon,
          * or false if the dataset cannot be rendered in the map.
          */
-         var getDatasetDeleteClasses = _.bind(function (dataset) {
+        var getDatasetDeleteClasses = _.bind(function (dataset) {
             return dataset.get('displayed') ? 'm-icon-disabled m-dataset-in-session' : 'm-icon-enabled m-delete-dataset';
         }, this);
 
@@ -224,14 +224,14 @@ minerva.views.DataPanel = minerva.views.Panel.extend({
          * or false if the dataset does not have the ability to have map rendering configured.
          */
         var getGeoRenderingConfigClasses = _.bind(function (dataset) {
-            var geoRenderType = dataset.getGeoRenderType()
+            var geoRenderType = dataset.getGeoRenderType();
             if (geoRenderType !== null && geoRenderType !== 'wms') {
-              var classes = 'm-configure-geo-render';
-              classes += (dataset.get('displayed') ? ' m-icon-disabled' : ' m-icon-enabled');
-              classes += ((!dataset.get('displayed') && dataset.get('geoError')) ? ' m-geo-render-error' : '');
-              return classes;
+                var classes = 'm-configure-geo-render';
+                classes += (dataset.get('displayed') ? ' m-icon-disabled' : ' m-icon-enabled');
+                classes += ((!dataset.get('displayed') && dataset.get('geoError')) ? ' m-geo-render-error' : '');
+                return classes;
             } else {
-              return false;
+                return false;
             }
         }, this);
 

--- a/web_external/stylesheets/body/dataPanel.styl
+++ b/web_external/stylesheets/body/dataPanel.styl
@@ -10,11 +10,14 @@
 
     i
       color #444
-    .icon-disabled
+
+    .m-icon-disabled
       color #f0f0f0
-    .icon-enabled:hover
+
+    .m-icon-enabled:hover
       color #66a
       cursor pointer
+
     .icon-info-circled
       float right
     .icon-right-circled

--- a/web_external/templates/body/dataPanel.jade
+++ b/web_external/templates/body/dataPanel.jade
@@ -12,14 +12,14 @@ if datasets
           span(title=name)= name
             - var attributes = {'m-dataset-id': dataset.get('_id')}
 
-            // Render the dataset in the map
+            // Render the dataset in the map.
             - var geoRenderClasses = getGeoRenderingClasses(dataset)
             if geoRenderClasses
               i(class='icon-eye ' + geoRenderClasses)&attributes(attributes)
 
-            //- Trash icon to delete dataset
-            - var classes = (dataset.get('displayed') ? 'icon-trash delete-dataset icon-disabled dataset-in-session' : 'icon-trash delete-dataset icon-enabled')
-            i(class=classes)&attributes(attributes)
+            // Delete the dataset.
+            - var deleteClasses = getDatasetDeleteClasses(dataset)
+            i(class='icon-trash ' + deleteClasses)&attributes(attributes)
 
             //- Info icon for minerva metadata display
             i.icon-info-circled.icon-enabled.dataset-info&attributes(attributes)

--- a/web_external/templates/body/dataPanel.jade
+++ b/web_external/templates/body/dataPanel.jade
@@ -24,10 +24,7 @@ if datasets
             // Display the minerva metadata.
             i.icon-info-circled.m-icon-enabled.m-dataset-info&attributes(attributes)
 
-            - var geoRenderType = dataset.getGeoRenderType()
-            //- Cog icon for geo rendering configuration
-            if geoRenderType !== null && geoRenderType !== 'wms'
-              - var classes = 'icon-cog m-configure-geo-render'
-              - classes += (dataset.get('displayed') ? ' icon-disabled dataset-in-session' : ' icon-enabled');
-              - classes += ((!dataset.get('displayed') && dataset.get('geoError')) ? ' m-geo-render-error' : '');
-              i(class=classes)&attributes(attributes)
+            // Map rendering configuration.
+            - var geoRenderingConfigClasses = getGeoRenderingConfigClasses(dataset)
+            if geoRenderingConfigClasses
+              i(class='icon-cog ' + geoRenderingConfigClasses)&attributes(attributes)

--- a/web_external/templates/body/dataPanel.jade
+++ b/web_external/templates/body/dataPanel.jade
@@ -21,10 +21,10 @@ if datasets
             - var deleteClasses = getDatasetDeleteClasses(dataset)
             i(class='icon-trash ' + deleteClasses)&attributes(attributes)
 
-            //- Info icon for minerva metadata display
-            i.icon-info-circled.icon-enabled.dataset-info&attributes(attributes)
-            - var geoRenderType = dataset.getGeoRenderType()
+            // Display the minerva metadata.
+            i.icon-info-circled.m-icon-enabled.m-dataset-info&attributes(attributes)
 
+            - var geoRenderType = dataset.getGeoRenderType()
             //- Cog icon for geo rendering configuration
             if geoRenderType !== null && geoRenderType !== 'wms'
               - var classes = 'icon-cog m-configure-geo-render'

--- a/web_external/templates/body/dataPanel.jade
+++ b/web_external/templates/body/dataPanel.jade
@@ -10,13 +10,12 @@ if datasets
         .dataset
           - var name = getDisplayName(dataset)
           span(title=name)= name
-
             - var attributes = {'m-dataset-id': dataset.get('_id')}
 
-            //- Eye icon to move dataset into current session
-            if dataset.isGeoRenderable()
-              - var classes = (dataset.get('displayed') ? 'icon-eye icon-disabled dataset-in-session' : 'icon-eye icon-enabled add-dataset-to-session')
-              i(class=classes)&attributes(attributes)
+            // Render the dataset in the map
+            - var geoRenderClasses = getGeoRenderingClasses(dataset)
+            if geoRenderClasses
+              i(class='icon-eye ' + geoRenderClasses)&attributes(attributes)
 
             //- Trash icon to delete dataset
             - var classes = (dataset.get('displayed') ? 'icon-trash delete-dataset icon-disabled dataset-in-session' : 'icon-trash delete-dataset icon-enabled')

--- a/web_external/templates/body/dataPanel.jade
+++ b/web_external/templates/body/dataPanel.jade
@@ -7,27 +7,26 @@ if datasets
   +panel-content('collapse in')
     .datasets
       each dataset in datasets
-        if dataset.metadata()
-          .dataset
-            span(title=dataset.get('name'))= dataset.get('name').length > 13 ? dataset.get('name').slice(0,13) + "..." : dataset.get('name')
-              - var attributes = {'m-dataset-id': dataset.get('_id')}
+        .dataset
+          span(title=dataset.get('name'))= dataset.get('name').length > 13 ? dataset.get('name').slice(0,13) + "..." : dataset.get('name')
+            - var attributes = {'m-dataset-id': dataset.get('_id')}
 
-              //- Eye icon to move dataset into current session
-              if dataset.isGeoRenderable()
-                - var classes = (dataset.get('displayed') ? 'icon-eye icon-disabled dataset-in-session' : 'icon-eye icon-enabled add-dataset-to-session')
-                i(class=classes)&attributes(attributes)
-
-              //- Trash icon to delete dataset
-              - var classes = (dataset.get('displayed') ? 'icon-trash delete-dataset icon-disabled dataset-in-session' : 'icon-trash delete-dataset icon-enabled')
+            //- Eye icon to move dataset into current session
+            if dataset.isGeoRenderable()
+              - var classes = (dataset.get('displayed') ? 'icon-eye icon-disabled dataset-in-session' : 'icon-eye icon-enabled add-dataset-to-session')
               i(class=classes)&attributes(attributes)
 
-              //- Info icon for minerva metadata display
-              i.icon-info-circled.icon-enabled.dataset-info&attributes(attributes)
-              - var geoRenderType = dataset.getGeoRenderType()
+            //- Trash icon to delete dataset
+            - var classes = (dataset.get('displayed') ? 'icon-trash delete-dataset icon-disabled dataset-in-session' : 'icon-trash delete-dataset icon-enabled')
+            i(class=classes)&attributes(attributes)
 
-              //- Cog icon for geo rendering configuration
-              if geoRenderType !== null && geoRenderType !== 'wms'
-                - var classes = 'icon-cog m-configure-geo-render'
-                - classes += (dataset.get('displayed') ? ' icon-disabled dataset-in-session' : ' icon-enabled');
-                - classes += ((!dataset.get('displayed') && dataset.get('geoError')) ? ' m-geo-render-error' : '');
-                i(class=classes)&attributes(attributes)
+            //- Info icon for minerva metadata display
+            i.icon-info-circled.icon-enabled.dataset-info&attributes(attributes)
+            - var geoRenderType = dataset.getGeoRenderType()
+
+            //- Cog icon for geo rendering configuration
+            if geoRenderType !== null && geoRenderType !== 'wms'
+              - var classes = 'icon-cog m-configure-geo-render'
+              - classes += (dataset.get('displayed') ? ' icon-disabled dataset-in-session' : ' icon-enabled');
+              - classes += ((!dataset.get('displayed') && dataset.get('geoError')) ? ' m-geo-render-error' : '');
+              i(class=classes)&attributes(attributes)

--- a/web_external/templates/body/dataPanel.jade
+++ b/web_external/templates/body/dataPanel.jade
@@ -8,7 +8,9 @@ if datasets
     .datasets
       each dataset in datasets
         .dataset
-          span(title=dataset.get('name'))= dataset.get('name').length > 13 ? dataset.get('name').slice(0,13) + "..." : dataset.get('name')
+          - var name = getDisplayName(dataset)
+          span(title=name)= name
+
             - var attributes = {'m-dataset-id': dataset.get('_id')}
 
             //- Eye icon to move dataset into current session


### PR DESCRIPTION
Ready for review.

I wanted to make the jade a bit more readable (helps by having shorter lines), and also

*  I also moved any logic related to the icon classes, especially any logic dependent on the state of the dataset, into the view.  I'm curious if others think this is a positive change.
* continued jsdoc expansion, this is hard to argue with
* namespacing event classes
* I kept any fontello icon classes in the jade, as this makes it easier to read the jade and see what icon to expect