### PR TITLE
Add a subcommand to generate BSVE authentication headers

### DIFF
--- a/server/utility/bsve/bsve_utility.py
+++ b/server/utility/bsve/bsve_utility.py
@@ -433,6 +433,10 @@ def main():
         default=None
     )
 
+    subparsers.add_parser(
+        'auth', help='Generate an authentication header.'
+    )
+
     args = parser.parse_args()
 
     if not (args.user and args.apikey and args.secretkey):
@@ -476,6 +480,8 @@ def main():
         output = bsve.soda_dump(
             count=args.count
         )
+    elif args.command == 'auth':
+        output = bsve._auth_header()
 
     if isinstance(output, (dict, list, tuple)):
         output = json.dumps(output, indent=2)


### PR DESCRIPTION
This was a common problem people had at the TIM.  We were already generating it, this just exposes it through the CLI so that I can point others to it on the developers' forum.