### PR TITLE
Update geojs to 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/Kitware/minerva.git",
   "dependencies": {
     "JSONPath": "0.10.0",
-    "geojs": "git+https://github.com/OpenGeoscience/geojs.git#v0.6.0",
+    "geojs": "git+https://github.com/OpenGeoscience/geojs.git#v0.7.0",
     "underscore": "~1.5",
     "jade": "1.3.1",
     "colorbrewer": "1.0.0",


### PR DESCRIPTION
@jbeezley @essamjoubori  or anyone else, PTAL.

To test this, especially if you haven't had a very recent master of Minerva, you'll need to ensure that

* your Girder is on version e61477c
* you have rebuilt the client (npm install)
* you kill your cherrypy server (python -m girder) and restart it (because we recently updated the mako template, and cherrypy needs to be recycled to serve the new template)

If that doesn't work, you can delete the girder/node_modules folder and the girder/plugins/minerva/node_modules folder then rerun npm install.  Expect to wait on this, and for many npm warnings.

Here's a screenshot from this branch showing 

* wms
* mongo
* geojson
* contour
* choropleth

datasets being rendered with the correct version of GeoJs.

<img width="808" alt="screen shot 2016-02-13 at 3 54 01 pm" src="https://cloud.githubusercontent.com/assets/595023/13030028/b6869086-d26a-11e5-88a1-6ddad6e70d73.png">
