### PR TITLE
[WIP] Add header back to layout

### DIFF
--- a/web_external/js/views/layout/HeaderView.js
+++ b/web_external/js/views/layout/HeaderView.js
@@ -3,6 +3,8 @@ minerva.views.LayoutHeaderView = minerva.View.extend({
     },
 
     render: function () {
+        this.$el.html(minerva.templates.layoutHeader());
+
         this.$('a[title]').tooltip({
             placement: 'bottom',
             delay: {show: 300}


### PR DESCRIPTION
@katelynnobrien @essamjoubori 

This will get you started for #306.

It adds the header back in, with the user login/logout/register (and user account management) components, along with a globe icon that takes you to the sessions list.  

You can see some problems here, like that the user header obscures the session header (they are stacking over each other) and the globe obscures the name of the session.

Similarly, on the session list page (which is going away anyway), the header obscures the session controls at the top.

![screen shot 2016-02-16 at 2 51 01 pm](https://cloud.githubusercontent.com/assets/595023/13089102/19d39342-d4bd-11e5-9f7a-b2f9a58130e2.png)
![screen shot 2016-02-16 at 2 51 12 pm](https://cloud.githubusercontent.com/assets/595023/13089103/1a95fafe-d4bd-11e5-9950-11a90f9ebb72.png)
