### PR TITLE
Ensure vagrant mongo listens on all addresses

### DIFF
--- a/ansible/roles/mongodb-install/templates/mongodb.conf.j2
+++ b/ansible/roles/mongodb-install/templates/mongodb.conf.j2
@@ -1,11 +1,6 @@
-
 dbpath=/var/lib/mongodb
 logpath=/var/log/mongodb.log
 logappend=true
-bind_ip={{ hostvars[inventory_hostname]
-                   ["ansible_" + mongodb_net_interface]
-                   ["ipv4"]
-                   ["address"] }}
+bind_ip=0.0.0.0
 port={{ mongodb_port }}
 journal=true
-


### PR DESCRIPTION
This makes sure mongo can accept connections from 127.0.0.1 which is a
convention in many people's set ups.

@mgrauer this should address your issue here:
https://github.com/Kitware/minerva/pull/259#issuecomment-185916337