### PR TITLE
Get ansible minerva version from current git branch

### DIFF
--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -39,7 +39,7 @@
       sudo: yes
 
     - role: minerva
-      minerva_version: "master"
+      minerva_version: "{{ lookup('pipe', 'git rev-parse --abbrev-ref HEAD') }}"
       sudo: yes
 
   tasks:

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -39,7 +39,7 @@
       sudo: yes
 
     - role: minerva
-      minerva_version: "{{ lookup('pipe', 'git rev-parse --abbrev-ref HEAD') }}"
+      minerva_version: "{{ lookup('pipe', 'git rev-parse --abbrev-ref HEAD 2>/dev/null || echo master') }}"
       sudo: yes
 
   tasks:


### PR DESCRIPTION
This feature will provision the ansible/vagrant version of minerva using the current git branch, to be set as minerva_version.

E.g.  On my host, I'm on git branch `feature_foo_la_la`, and I provision a new VM.  The minerva on that VM will be on git branch `feature_foo_la_la` as well.  If my minerva git branch on my host is `master`, then the VM minerva will be provisioned on `master` as well.



@kotfic 

I got this working while QA-ing #315.  Fixes #303.

PTAL.