### PR TITLE
Save session as item metadata instead of json file

### DIFF
--- a/web_external/js/MinervaModel.js
+++ b/web_external/js/MinervaModel.js
@@ -9,6 +9,14 @@ minerva.models.MinervaModel = girder.models.ItemModel.extend({
         }
     },
 
+    /*
+     * Utility method to get this model's current minerva metadata as
+     * it exists on the client, updating this model's minerva metadata to the
+     * minervaMetadata param if passed, but will not save the update.
+     *
+     * @param {minervaMetadata} the object to set as this model's minerva metadata if passed.
+     * @returns {object} current minerva metadata of this model.
+     */
     metadata: function (minervaMetadata) {
         if (minervaMetadata) {
             this.setMinervaMetadata(minervaMetadata);
@@ -17,6 +25,11 @@ minerva.models.MinervaModel = girder.models.ItemModel.extend({
         }
     },
 
+    /*
+     * Gets this model's current minerva metadata as it exists on the client.
+     *
+     * @returns {object} current minerva metadata of this model.
+     */
     getMinervaMetadata: function () {
         // for now assume that keys exists and allow exceptions to happen if they don't
         var meta = this.get('meta');
@@ -28,6 +41,12 @@ minerva.models.MinervaModel = girder.models.ItemModel.extend({
         }
     },
 
+    /*
+     * Sets this model's minerva metadata to the passed object, but does not save
+     * the update.
+     *
+     * @param {minervaMetadata} the object to set as this model's minerva metadata.
+     */
     setMinervaMetadata: function (minervaMetadata) {
         this.set('meta', _.extend(this.get('meta') || {}, {minerva: minervaMetadata}));
         if (minervaMetadata.geojson && minervaMetadata.geojson.data) {
@@ -37,6 +56,14 @@ minerva.models.MinervaModel = girder.models.ItemModel.extend({
         return minervaMetadata;
     },
 
+    /*
+     * Async function that saves the metadata on this model, either the current minerva
+     * metadata on the model, or if a minervaMetadata param is passed, first updating the
+     * minerva metadata on this model to the passed object and then saving.
+     *
+     * @param {minervaMetadata} the object to set as this model's minerva metadata before saving.
+     * @fires 'minerva.metadata.saved' event upon the metadata being saved.
+     */
     saveMinervaMetadata: function (minervaMetadata) {
         if (minervaMetadata) {
             this.setMinervaMetadata(minervaMetadata);
@@ -47,7 +74,7 @@ minerva.models.MinervaModel = girder.models.ItemModel.extend({
             contentType: 'application/json',
             data: JSON.stringify(this.get('meta'))
         }).done(_.bind(function () {
-            this.trigger('m:minervaMetadataSaved', this);
+            this.trigger('minerva.metadata.saved', this);
         }, this)).error(_.bind(function (err) {
             console.error(err);
             girder.events.trigger('g:alert', {
@@ -58,5 +85,4 @@ minerva.models.MinervaModel = girder.models.ItemModel.extend({
             });
         }, this));
     }
-
 });

--- a/web_external/js/MinervaModel.js
+++ b/web_external/js/MinervaModel.js
@@ -9,7 +9,7 @@ minerva.models.MinervaModel = girder.models.ItemModel.extend({
         }
     },
 
-    /*
+    /**
      * Utility method to get this model's current minerva metadata as
      * it exists on the client, updating this model's minerva metadata to the
      * minervaMetadata param if passed, but will not save the update.
@@ -25,7 +25,7 @@ minerva.models.MinervaModel = girder.models.ItemModel.extend({
         }
     },
 
-    /*
+    /**
      * Gets this model's current minerva metadata as it exists on the client.
      *
      * @returns {object} current minerva metadata of this model.
@@ -41,7 +41,7 @@ minerva.models.MinervaModel = girder.models.ItemModel.extend({
         }
     },
 
-    /*
+    /**
      * Sets this model's minerva metadata to the passed object, but does not save
      * the update.
      *
@@ -56,7 +56,7 @@ minerva.models.MinervaModel = girder.models.ItemModel.extend({
         return minervaMetadata;
     },
 
-    /*
+    /**
      * Async function that saves the metadata on this model, either the current minerva
      * metadata on the model, or if a minervaMetadata param is passed, first updating the
      * minerva metadata on this model to the passed object and then saving.

--- a/web_external/js/MinervaModel.js
+++ b/web_external/js/MinervaModel.js
@@ -62,7 +62,7 @@ minerva.models.MinervaModel = girder.models.ItemModel.extend({
      * minerva metadata on this model to the passed object and then saving.
      *
      * @param {minervaMetadata} the object to set as this model's minerva metadata before saving.
-     * @fires 'minerva.metadata.saved' event upon the metadata being saved.
+     * @fires 'm:metadata_saved' event upon the metadata being saved.
      */
     saveMinervaMetadata: function (minervaMetadata) {
         if (minervaMetadata) {
@@ -74,7 +74,7 @@ minerva.models.MinervaModel = girder.models.ItemModel.extend({
             contentType: 'application/json',
             data: JSON.stringify(this.get('meta'))
         }).done(_.bind(function () {
-            this.trigger('minerva.metadata.saved', this);
+            this.trigger('m:metadata_saved', this);
         }, this)).error(_.bind(function (err) {
             console.error(err);
             girder.events.trigger('g:alert', {

--- a/web_external/js/models/DatasetModel.js
+++ b/web_external/js/models/DatasetModel.js
@@ -18,7 +18,7 @@ minerva.models.DatasetModel = minerva.models.MinervaModel.extend({
      * promote the Item to a Minerva Dataset, which means
      * initializing the Item's 'minerva' namespaced metadata.
      *
-     * @fires 'minerva.dataset.promoted' event upon successful Dataset promotion.
+     * @fires 'm:dataset_promoted' event upon successful Dataset promotion.
      */
     promoteToDataset: function () {
         girder.restRequest({
@@ -27,7 +27,7 @@ minerva.models.DatasetModel = minerva.models.MinervaModel.extend({
         }).done(_.bind(function (resp) {
             this.metadata(resp.meta.minerva);
             this._initGeoRender();
-            this.trigger('minerva.dataset.promoted', this);
+            this.trigger('m:dataset_promoted', this);
         }, this)).error(_.bind(function (err) {
             console.error(err);
             girder.events.trigger('g:alert', {
@@ -126,7 +126,7 @@ minerva.models.DatasetModel = minerva.models.MinervaModel.extend({
      * Async function that loads any data needed by this dataset to render in GeoJs,
      * setting that data as an attribute on this dataset named 'geoData'.
      *
-     * @fires 'minerva.dataset.geo.dataLoaded' event upon the geo data being loaded.
+     * @fires 'm:dataset_geo_dataLoaded' event upon the geo data being loaded.
      */
     loadGeoData: function () {
         var mm = this.metadata();
@@ -135,7 +135,7 @@ minerva.models.DatasetModel = minerva.models.MinervaModel.extend({
                 // Some datasets have geojson in the metadata.
                 this.set('geoData', mm.geojson.data);
             }
-            this.trigger('minerva.dataset.geo.dataLoaded', this);
+            this.trigger('m:dataset_geo_dataLoaded', this);
         } else {
             var path = '/file/' + mm.geo_render.file_id + '/download';
             girder.restRequest({
@@ -145,7 +145,7 @@ minerva.models.DatasetModel = minerva.models.MinervaModel.extend({
                 dataType: null
             }).done(_.bind(function (data) {
                 this.set('geoData', data);
-                this.trigger('minerva.dataset.geo.dataLoaded', this);
+                this.trigger('m:dataset_geo_dataLoaded', this);
             }, this)).error(_.bind(function (err) {
                 console.error(err);
                 girder.events.trigger('g:alert', {

--- a/web_external/js/models/SessionModel.js
+++ b/web_external/js/models/SessionModel.js
@@ -1,11 +1,4 @@
-minerva.models.SessionModel = girder.models.ItemModel.extend({
-
-    defaults: {
-        sessionJsonFile: null,
-        sessionJsonContents: null
-    },
-
-    initialize: function () { },
+minerva.models.SessionModel = minerva.models.MinervaModel.extend({
 
     _featureFromDataset: function (dataset) {
         var feature = {
@@ -22,18 +15,19 @@ minerva.models.SessionModel = girder.models.ItemModel.extend({
 
     datasetInFeatures: function (dataset) {
         var datasetFinder = this._featureIdentityPredicate(this._featureFromDataset(dataset));
-        return _.some(this.sessionJsonContents.features, datasetFinder);
+        return _.some(this.metadata().map.features, datasetFinder);
     },
 
     addLayoutAttributes: function (panelView, attributes) {
-        if (!_.has(this.sessionJsonContents, 'layout')) {
-            this.sessionJsonContents.layout = {};
+        var metadata = this.metadata();
+        if (!_.has(metadata, 'layout')) {
+            metadata.layout = {};
         }
 
-        if (!_.has(_.keys(this.sessionJsonContents.layout, panelView))) {
-            this.sessionJsonContents.layout[panelView] = attributes;
+        if (!_.has(_.keys(metadata.layout, panelView))) {
+            metadata.layout[panelView] = attributes;
         } else {
-            _.extend(this.sessionJsonContents.layout[panelView], attributes);
+            _.extend(metadata.layout[panelView], attributes);
         }
     },
 
@@ -42,99 +36,54 @@ minerva.models.SessionModel = girder.models.ItemModel.extend({
         // may want to unify caching of geojson file id
         // TODO may need to be smarter about finding
         // especially if we copy the file into our session item and the ids change
+        var metadata = this.metadata().map;
         var feature = this._featureFromDataset(dataset);
-        if (!_.find(this.sessionJsonContents.features, this._featureIdentityPredicate(feature))) {
-            this.sessionJsonContents.features.push(feature);
+        if (!_.find(metadata.features, this._featureIdentityPredicate(feature))) {
+            metadata.features.push(feature);
         }
         // TODO may need to set this to changed because not using setX
     },
 
     removeDataset: function (dataset) {
+        var metadata = this.metadata().map;
         var feature = this._featureFromDataset(dataset);
         var featureIdentifier = this._featureIdentityPredicate(feature);
-        this.sessionJsonContents.features = _.reject(this.sessionJsonContents.features, featureIdentifier);
+        metadata.features = _.reject(metadata.features, featureIdentifier);
         // TODO may need to set this to changed because not using setX
     },
 
-    createSessionJson: function (callback) {
-        // TODO do this on the server side and just call it
-        // when we create the session item, want to create a session.json file in it
-        var sessionJsonContents = {};
-        sessionJsonContents.basemap = 'osm';
-        sessionJsonContents.basemap_args = {
+    /**
+     * Async function that initializes the session with minerva metadata, including some defaults
+     * for the map.
+     *
+     * @fires 'minerva.session.saved' event upon successful Session creation.
+     */
+    createSessionMetadata: function () {
+        var metadata = this.metadata() || {};
+        // TODO this is highly map centric, probably should be split out
+        var map = {};
+        map.basemap = 'osm';
+        map.basemap_args = {
             tileUrl: 'https://{s}.tiles.mapbox.com/v3/datamade.hn83a654/{z}/{x}/{y}.png',
             attribution: '<a href=http://www.mapbox.com/about/maps/ target=_blank>Terms &amp; Feedback</a>'
         };
-        sessionJsonContents.center = {x: -100, y: 36.5};
-        sessionJsonContents.zoom = 4;
-        sessionJsonContents.features = [];
-        // now save this as session.json as a file in the item
-        this.sessionJsonFile = new girder.models.FileModel();
-        this.sessionJsonFile.on('g:upload.complete', function () {
-            callback();
-        }, this).uploadToItem(this, JSON.stringify(sessionJsonContents), 'session.json', 'application/json');
+        map.center = {x: -100, y: 36.5};
+        map.zoom = 4;
+        map.features = [];
+        metadata.map = map;
+        this.on('minerva.metadata.saved', function () {
+            this.trigger('minerva.session.saved', this);
+        }, this).saveMinervaMetadata(metadata);
     },
 
-    fetch: function () {
-        this.on('g:fetched', function () {
-            // now get the session file
-            var sessionParams = {
-                path: 'minerva_session/' + this.get('_id') + '/session',
-                type: 'GET'
-            };
-            girder.restRequest(sessionParams).done(_.bind(function (file) {
-                this.sessionJsonFile = new girder.models.FileModel(file);
-                // TODO if there isn't one need to create it
-                // now we have the file, get the actual contents
-                girder.restRequest({
-                    path: 'file/' + file._id + '/download',
-                    type: 'GET'
-                }).done(_.bind(function (resp) {
-                    this.sessionJsonContents = resp;
-                    this.trigger('m:fetched');
-                }, this)).error(_.bind(function (err) {
-                    console.error(err);
-                    girder.events.trigger('g:alert', {
-                        icon: 'cancel',
-                        text: 'Could not download session json contents.',
-                        type: 'error',
-                        timeout: 4000
-                    });
-                }, this));
-            }, this)).error(_.bind(function (err) {
-                console.error(err);
-                girder.events.trigger('g:alert', {
-                    icon: 'cancel',
-                    text: 'Could not load session item.',
-                    type: 'error',
-                    timeout: 4000
-                });
-            }, this));
-        }, this).on('g:error', function () {
-            minerva.router.navigate('sessions', {trigger: true});
-        }, this);
-        girder.models.ItemModel.prototype.fetch.call(this);
-    },
-    // when we load the session item, want to load the session.json file in it
-    // will also make a file for each geojson dataset we want to add in
-    // this will be a pointer in girder
-
-    // the standard save for this model will save this item
-    // here we save the session.json and any files that should be a part of the item
+    /**
+     * Async function that saves the session's minerva metadata.
+     *
+     * @fires 'minerva.session.saved' event upon successful Session save.
+     */
     saveSession: function () {
-        // TODO will want more info on features, possibly layer or transparency or mapping or ??
-        // for now just save the fileid
-        // update the json, save it
-        this.sessionJsonFile.on('g:upload.complete', function () {
-            this.trigger('m:saved');
-            // TODO some work here
-            // may want to add or remove any files needed into the item
-            // hold off for now
-            // will need to get the complete list of files for the item
-            // dealing with pagination
-            // then compare that to the list of files as features
-            // delete any in files and not in features
-            // add any in features and not in files
-        }, this).updateContents(JSON.stringify(this.sessionJsonContents));
+        this.on('minerva.metadata.saved', function () {
+            this.trigger('minerva.session.saved', this);
+        }, this).saveMinervaMetadata();
     }
 });

--- a/web_external/js/models/SessionModel.js
+++ b/web_external/js/models/SessionModel.js
@@ -56,7 +56,7 @@ minerva.models.SessionModel = minerva.models.MinervaModel.extend({
      * Async function that initializes the session with minerva metadata, including some defaults
      * for the map.
      *
-     * @fires 'minerva.session.saved' event upon successful Session creation.
+     * @fires 'm:session_saved' event upon successful Session creation.
      */
     createSessionMetadata: function () {
         var metadata = this.metadata() || {};
@@ -71,19 +71,19 @@ minerva.models.SessionModel = minerva.models.MinervaModel.extend({
         map.zoom = 4;
         map.features = [];
         metadata.map = map;
-        this.on('minerva.metadata.saved', function () {
-            this.trigger('minerva.session.saved', this);
+        this.on('m:metadata_saved', function () {
+            this.trigger('m:session_saved', this);
         }, this).saveMinervaMetadata(metadata);
     },
 
     /**
      * Async function that saves the session's minerva metadata.
      *
-     * @fires 'minerva.session.saved' event upon successful Session save.
+     * @fires 'm:session_saved' event upon successful Session save.
      */
     saveSession: function () {
-        this.on('minerva.metadata.saved', function () {
-            this.trigger('minerva.session.saved', this);
+        this.on('m:metadata_saved', function () {
+            this.trigger('m:session_saved', this);
         }, this).saveMinervaMetadata();
     }
 });

--- a/web_external/js/views/body/DataPanel.js
+++ b/web_external/js/views/body/DataPanel.js
@@ -82,7 +82,7 @@ minerva.views.DataPanel = minerva.views.Panel.extend({
      * Promote an Item to a Dataset, then add it to the DatasetCollection.
      */
     uploadFinished: function () {
-        this.newDataset.on('minerva.dataset.promoted', function () {
+        this.newDataset.on('m:dataset_promoted', function () {
             this.collection.add(this.newDataset);
         }, this).on('g:error', function (err) {
             console.error(err);

--- a/web_external/js/views/body/MapPanel.js
+++ b/web_external/js/views/body/MapPanel.js
@@ -2,8 +2,8 @@ minerva.views.MapPanel = minerva.views.Panel.extend({
 
     events: {
         'click .m-save-current-baselayer': function () {
-            this.session.sessionJsonContents.center = this.map.center();
-            this.session.sessionJsonContents.zoom = this.map.zoom();
+            this.session.metadata().map.center = this.map.center();
+            this.session.metadata().map.zoom = this.map.zoom();
             this.session.saveSession();
         }
     },
@@ -275,7 +275,7 @@ minerva.views.MapPanel = minerva.views.Panel.extend({
             // TODO for now only dealing with center
             if (this.map) {
                 // TODO could better separate geojs needs from session storage
-                this.map.center(this.session.sessionJsonContents.center);
+                this.map.center(this.session.metadata().map.center);
             }
         });
         this.datasetLayers = {};
@@ -313,10 +313,11 @@ minerva.views.MapPanel = minerva.views.Panel.extend({
 
     renderMap: function () {
         if (!this.map) {
+            var mapSettings = this.session.metadata().map;
             this.map = geo.map({
                 node: '.m-map-panel-map',
-                center: this.session.sessionJsonContents.center,
-                zoom: this.session.sessionJsonContents.zoom,
+                center: mapSettings.center,
+                zoom: mapSettings.zoom,
                 interactor: geo.mapInteractor({
                     map: this.map,
                     click: {
@@ -325,9 +326,9 @@ minerva.views.MapPanel = minerva.views.Panel.extend({
                     }
                 })
             });
-            this.map.createLayer(this.session.sessionJsonContents.basemap,
-                                 _.has(this.session.sessionJsonContents, 'basemap_args')
-                                 ? this.session.sessionJsonContents.basemap_args : {});
+            this.map.createLayer(mapSettings.basemap,
+                                 _.has(mapSettings, 'basemap_args')
+                                 ? mapSettings.basemap_args : {});
             this.uiLayer = this.map.createLayer('ui');
             this.mapCreated = true;
             _.each(this.collection.models, function (dataset) {

--- a/web_external/js/views/body/MapPanel.js
+++ b/web_external/js/views/body/MapPanel.js
@@ -215,13 +215,13 @@ minerva.views.MapPanel = minerva.views.Panel.extend({
                 this.map.draw();
             } else if (renderType === 'choropleth') {
                 // hacktastic special handling of MMWR data
-                dataset.once('minerva.dataset.geo.dataLoaded', _.bind(function () {
+                dataset.once('m:dataset_geo_dataLoaded', _.bind(function () {
                     this._renderChoropleth(dataset, this.map.createLayer('feature'));
                 }, this));
                 dataset.loadGeoData();
             } else if (_.has(this.GEOJS_RENDER_TYPES_FILEREADER, renderType)) {
                 // Load the data and adapt the dataset to the map with the reader.
-                dataset.once('minerva.dataset.geo.dataLoaded', function () {
+                dataset.once('m:dataset_geo_dataLoaded', function () {
                     // TODO: allow these datasets to specify a legend.
                     var datasetId = dataset.get('_id');
                     var layer = this.map.createLayer('feature');

--- a/web_external/js/views/body/SessionView.js
+++ b/web_external/js/views/body/SessionView.js
@@ -128,7 +128,7 @@ minerva.views.SessionView = minerva.View.extend({
         this.listenTo(this.model, 'change', function () {
             this._enableSave();
         });
-        this.listenTo(this.model, 'minerva.session.saved', function () {
+        this.listenTo(this.model, 'm:session_saved', function () {
             this._disableSave();
         });
 

--- a/web_external/js/views/body/SessionView.js
+++ b/web_external/js/views/body/SessionView.js
@@ -66,26 +66,26 @@ minerva.views.SessionView = minerva.View.extend({
     },
 
     getEnabledPanelGroups: function () {
-        if (!_.has(this.model.sessionJsonContents, 'layout')) {
+        if (!_.has(this.model.metadata(), 'layout')) {
             return this.layout.panelGroups;
         }
 
         return _.filter(this.layout.panelGroups, function (panelGroup) {
-            return !(_.has(this.model.sessionJsonContents.layout, panelGroup.id) &&
-                     _.has(this.model.sessionJsonContents.layout[panelGroup.id], 'disabled') &&
-                     this.model.sessionJsonContents.layout[panelGroup.id].disabled === true);
+            return !(_.has(this.model.metadata().layout, panelGroup.id) &&
+                     _.has(this.model.metadata().layout[panelGroup.id], 'disabled') &&
+                     this.model.metadata().layout[panelGroup.id].disabled === true);
         }, this);
     },
 
     getEnabledPanelViews: function (panelGroup) {
-        if (!_.has(this.model.sessionJsonContents, 'layout')) {
+        if (!_.has(this.model.metadata(), 'layout')) {
             return panelGroup.panelViews;
         }
 
         return _.filter(panelGroup.panelViews, function (panelView) {
-            return !(_.has(this.model.sessionJsonContents.layout, panelView.id) &&
-                     _.has(this.model.sessionJsonContents.layout[panelView.id], 'disabled') &&
-                     this.model.sessionJsonContents.layout[panelView.id].disabled === true);
+            return !(_.has(this.model.metadata().layout, panelView.id) &&
+                     _.has(this.model.metadata().layout[panelView.id], 'disabled') &&
+                     this.model.metadata().layout[panelView.id].disabled === true);
         }, this);
     },
 
@@ -128,7 +128,7 @@ minerva.views.SessionView = minerva.View.extend({
         this.listenTo(this.model, 'change', function () {
             this._enableSave();
         });
-        this.listenTo(this.model, 'm:saved', function () {
+        this.listenTo(this.model, 'minerva.session.saved', function () {
             this._disableSave();
         });
 
@@ -202,8 +202,8 @@ minerva.views.SessionView = minerva.View.extend({
             }, this);
 
             // Restore state of collapsed panels
-            if (_.has(this.model.sessionJsonContents, 'layout')) {
-                _.each(this.model.sessionJsonContents.layout, function (panelView, panelViewId) {
+            if (_.has(this.model.metadata(), 'layout')) {
+                _.each(this.model.metadata().layout, function (panelView, panelViewId) {
                     if (_.has(panelView, 'collapsed') && panelView.collapsed === true) {
                         $('#' + panelViewId).find('i.icon-up-open').trigger('click');
                     }
@@ -224,7 +224,7 @@ minerva.router.route('session/:id', 'session', function (id) {
     var session = new minerva.models.SessionModel();
     session.set({
         _id: id
-    }).once('m:fetched', function () {
+    }).once('g:fetched', function () {
         var datasetsCollection = new minerva.collections.DatasetCollection();
         datasetsCollection.once('g:changed', function () {
             var analysisCollection = new minerva.collections.AnalysisCollection();

--- a/web_external/js/views/body/SessionsView.js
+++ b/web_external/js/views/body/SessionsView.js
@@ -3,7 +3,7 @@ minerva.views.SessionsView = minerva.View.extend({
     events: {
         'click a.m-session-link': function (event) {
             var cid = $(event.currentTarget).attr('m-session-cid');
-            minerva.router.navigate('session/' + this.collection.get(cid).id, {trigger: true});
+            minerva.router.navigate('session/' + this.collection.get(cid).get('_id'), {trigger: true});
         },
 
         'click .m-session-create-button': 'createDialog'

--- a/web_external/js/views/widgets/EditSessionWidget.js
+++ b/web_external/js/views/widgets/EditSessionWidget.js
@@ -70,7 +70,7 @@ minerva.views.EditSessionWidget = minerva.View.extend({
         }));
         session.on('g:saved', function () {
             this.$el.modal('hide');
-            session.on('minerva.session.saved', function () {
+            session.on('m:session_saved', function () {
                 this.trigger('g:saved', session);
             }, this);
             session.createSessionMetadata();

--- a/web_external/js/views/widgets/EditSessionWidget.js
+++ b/web_external/js/views/widgets/EditSessionWidget.js
@@ -70,9 +70,10 @@ minerva.views.EditSessionWidget = minerva.View.extend({
         }));
         session.on('g:saved', function () {
             this.$el.modal('hide');
-            session.createSessionJson(_.bind(function () {
+            session.on('minerva.session.saved', function () {
                 this.trigger('g:saved', session);
-            }, this));
+            }, this);
+            session.createSessionMetadata();
         }, this).off('g:error').on('g:error', function (err) {
             this.$('.g-validation-failed-message').text(err.responseJSON.message);
             this.$('button.m-save-phase').removeClass('disabled');

--- a/web_external/js/views/widgets/KeymapWidget.js
+++ b/web_external/js/views/widgets/KeymapWidget.js
@@ -26,7 +26,7 @@ minerva.views.KeymapWidget = minerva.View.extend({
 
             // save the dataset with updated metadata
             this.$('button.m-save-keymap-mapping').addClass('disabled');
-            this.dataset.once('minerva.metadata.saved', function () {
+            this.dataset.once('m:metadata_saved', function () {
                 this.dataset.on('m:geojsonCreated', function () {
                     this.$el.modal('hide');
                     // TODO is this ok to do?

--- a/web_external/js/views/widgets/KeymapWidget.js
+++ b/web_external/js/views/widgets/KeymapWidget.js
@@ -26,7 +26,7 @@ minerva.views.KeymapWidget = minerva.View.extend({
 
             // save the dataset with updated metadata
             this.$('button.m-save-keymap-mapping').addClass('disabled');
-            this.dataset.once('m:minervaMetadataSaved', function () {
+            this.dataset.once('minerva.metadata.saved', function () {
                 this.dataset.on('m:geojsonCreated', function () {
                     this.$el.modal('hide');
                     // TODO is this ok to do?

--- a/web_external/js/views/widgets/TableWidget.js
+++ b/web_external/js/views/widgets/TableWidget.js
@@ -27,7 +27,7 @@ minerva.views.TableWidget = minerva.View.extend({
 
             // save the dataset with updated metadata
             this.$('button.m-save-table-mapping').addClass('disabled');
-            this.dataset.once('minerva.metadata.saved', function () {
+            this.dataset.once('m:metadata_saved', function () {
                 this.dataset.on('m:geojsonCreatedFromTabular', function () {
                     this.$el.modal('hide');
                     // TODO is this ok to do?

--- a/web_external/js/views/widgets/TableWidget.js
+++ b/web_external/js/views/widgets/TableWidget.js
@@ -27,7 +27,7 @@ minerva.views.TableWidget = minerva.View.extend({
 
             // save the dataset with updated metadata
             this.$('button.m-save-table-mapping').addClass('disabled');
-            this.dataset.once('m:minervaMetadataSaved', function () {
+            this.dataset.once('minerva.metadata.saved', function () {
                 this.dataset.on('m:geojsonCreatedFromTabular', function () {
                     this.$el.modal('hide');
                     // TODO is this ok to do?


### PR DESCRIPTION
This changes the Session model to save its Minerva metadata in the Girder Item metadata, just as with the other models.  

Note that to QA this and once this goes in, you'll have to delete all of the Items in your Girder user's minerva/session folder as they are incompatible.

@jbeezley PTAL.

Fixes #317.