### PR TITLE
[WIP] Add grunt init to copy assets

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -157,6 +157,16 @@ module.exports = function (grunt) {
             }
         },
         copy: {
+            'assets': {
+                files: [
+                    {
+                        expand: true,
+                        cwd: '<%= plugin.minerva.external %>/assets/',
+                        src: ['*.png'],
+                        dest: '<%= plugin.minerva.static %>/assets/'
+                    }
+                ]
+            },
             'papaparse': {
                 files: [
                     {
@@ -245,6 +255,9 @@ module.exports = function (grunt) {
             }
         },
         init: {
+            'copy:assets': {
+                dependencies: []
+            },
             'shell:minerva-geojs-install': {
                 dependencies: ['shell:plugin-install']
             },


### PR DESCRIPTION
@katelynnobrien 

This branch should get you started.

If you create a `web_external/assets` directory, when you run `grunt init` (or `npm install` which calls `grunt init`) at the top level under your `girder` dir, this will copy any .png files you put in `assets` to the static built directory for minerva.

In a Javascript file, you need to pass the `staticRoot` to your jade template 

        this.$el.html(minerva.templates.layoutHeader({
            staticRoot: girder.staticRoot
        }));

and in a jade template (that you passed in the `staticRoot` variable to) you could do

    img(src="#{staticRoot}/built/plugins/minerva/assets/awesome-image.png")
