### PR TITLE
Improve travis caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,9 @@ addons:
     - libnetcdf-dev
 
 before_install:
+    # update pip for binary wheel caching
+    - pip install -U pip virtualenv
+
     # minerva has been cloned to Kitware/minerva by travis
     # girder needs to be cloned and then minerva moved under girder
     - cd $HOME/build

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,15 +70,7 @@ before_install:
     - CACHE=$HOME/.cache CMAKE_VERSION=3.1.0 CMAKE_SHORT_VERSION=3.1 source $HOME/build/girder/scripts/install_cmake.sh
 
     # install spark
-    - cd $HOME
-    - wget http://www.scala-lang.org/files/archive/scala-2.10.5.tgz
-    - tar xzvf scala-2.10.5.tgz -C ~
-    - export SCALA_HOME=$HOME/scala-2.10.5
-    - export PATH=$PATH:$SCALA_HOME/bin
-    # spark may be cached
-    - export SPARK_HOME=$HOME/spark-1.3.1-bin-hadoop2.4
-    - if [ ! -f $SPARK_HOME/sbin/start-master.sh ]; then wget http://d3kbcqa49mib13.cloudfront.net/spark-1.3.1-bin-hadoop2.4.tgz; fi
-    - if [ ! -f $SPARK_HOME/sbin/start-master.sh ]; then tar xzvf spark-1.3.1-bin-hadoop2.4.tgz -C ~; fi
+    - CACHE=$HOME/.cache SCALA_VERSION=2.10.5 SPARK_VERSION=1.3.1 source $HOME/build/girder/plugins/minerva/.travis/install_spark.sh
     - export SPARK_MASTER_IP=localhost
     - $SPARK_HOME/sbin/start-master.sh
     - sleep 3

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,7 @@ env:
 cache:
   directories:
   - $HOME/virtualenv/python2.7.9
-  - $HOME/.cache/pip
-  - $HOME/.cache/node_modules
+  - $HOME/.cache
   - $HOME/spark-1.3.1-bin-hadoop2.4
 
 sudo: false
@@ -62,19 +61,13 @@ before_install:
     - if [ -n "${PY3}" ]; then export MONGO_VERSION=3.0.2; export PY_COVG="OFF"; else export MONGO_VERSION=2.6.9; export PY_COVG="ON"; export DEPLOY=true; fi
 
     # mongo
-    - pushd "${HOME}"
-    - curl "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-${MONGO_VERSION}.tgz" | gunzip -c | tar x
-    - cd mongodb-*/bin && export PATH="${PWD}:${PATH}"
-    - popd
+    - CACHE=$HOME/.cache source $HOME/build/girder/scripts/install_mongo.sh
     - mkdir /tmp/db
     - mongod --dbpath=/tmp/db >/dev/null 2>/dev/null &
     - mongod --version
 
     # cmake
-    - cd $HOME
-    - curl -L "http://cmake.org/files/v3.1/cmake-3.1.0-Linux-x86_64.tar.gz" | gunzip -c | tar x
-    - cd cmake-*/bin && export PATH="${PWD}:${PATH}"
-    - cmake --version
+    - CACHE=$HOME/.cache CMAKE_VERSION=3.1.0 CMAKE_SHORT_VERSION=3.1 source $HOME/build/girder/scripts/install_cmake.sh
 
     # install spark
     - cd $HOME

--- a/.travis/install_spark.sh
+++ b/.travis/install_spark.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+PREFIX="$CACHE/scala-$SCALA_VERSION"
+if [[ ! -f "$PREFIX/bin/scala" || -n "$UPDATE_CACHE" ]] ; then
+  rm -fr "$PREFIX"
+  mkdir -p "$PREFIX"
+  curl -L "http://www.scala-lang.org/files/archive/scala-${SCALA_VERSION}.tgz" | gunzip -c | tar -x -C "$PREFIX" --strip-components 1
+fi
+export SCALA_HOME="$PREFIX"
+export PATH="$PREFIX/bin:$PATH"
+
+PREFIX="$CACHE/spark-$SPARK_VERSION"
+if [[ ! -f "$PREFIX/sbin/start-master.sh" || -n "$UPDATE_CACHE" ]] ; then
+  rm -fr "$PREFIX"
+  mkdir -p "$PREFIX"
+  curl -L "http://d3kbcqa49mib13.cloudfront.net/spark-${SPARK_VERSION}-bin-hadoop2.4.tgz" | gunzip -c | tar -x -C "$PREFIX" --strip-components 1
+fi
+export SPARK_HOME="$PREFIX"
+export PATH="$PREFIX/bin:$PREFIX/sbin:$PATH"


### PR DESCRIPTION
This updates pip on travis to (re)enable binary wheel caching.  It looks like it brings the pip install step down from 6 minutes to 10 seconds.

I also went ahead and cached the installs of cmake and mongo using the scripts girder uses, and I added similar scripts for spark and scala.