### PR TITLE
Add dataset output of job to collection

### DIFF
--- a/web_external/js/views/body/DataPanel.js
+++ b/web_external/js/views/body/DataPanel.js
@@ -181,7 +181,15 @@ minerva.views.DataPanel = minerva.views.Panel.extend({
         girder.eventStream.on('g:event.job_status', _.bind(function (event) {
             var status = window.parseInt(event.data.status);
             if (status === girder.jobs_JobStatus.SUCCESS) {
-                this.collection.fetch({}, true);
+                if (event.data && event.data.meta && event.data.meta.minerva &&
+                   event.data.meta.minerva.outputs && event.data.meta.minerva.outputs.length > 0 &&
+                   event.data.meta.minerva.outputs[0].dataset_id) {
+                    var datasetId = event.data.meta.minerva.outputs[0].dataset_id;
+                    var dataset = new minerva.models.DatasetModel({ _id: datasetId });
+                    dataset.on('g:fetched', function () {
+                        this.collection.add(dataset);
+                    }, this).fetch();
+                }
             }
         }, this));
 


### PR DESCRIPTION
Fixes #163.

@jbeezley 

This is probably easiest for you to QA b/c I know you can run jobs (MMWR).

The issue is that we were fetching the dataset collection whenever a job succeeded, but that was stomping on the `displayed` state of datasets in the collection.

So if you start out with a dataset that is visualized in the map

![screen shot 2016-03-01 at 10 59 58 am](https://cloud.githubusercontent.com/assets/595023/13433006/01c8169c-df9e-11e5-8af2-c06bc949af53.png)

And then you run a job, when that job finishes, the dataset collection will be fetched and the dataset output of your job will be included in the dataset panel.  Here it is `before_fix`.  When you try to render that new (or any other additional) dataset on the map, the earlier dataset remains visualized, but it is no longer reflected in the Session Layers panel, and you can't remove the previous layer from the map display.

![screen shot 2016-03-01 at 11 00 43 am](https://cloud.githubusercontent.com/assets/595023/13433069/426c209e-df9e-11e5-81d4-aa050d694aed.png)

With this fix, since the dataset is added to the collection, the collection will be re-rendered but the datasets' `displayed` state within that collection won't change.  So you can then render the added dataset on top of the existing layers and the Session Layers panel will be correct.

![screen shot 2016-03-01 at 11 02 49 am](https://cloud.githubusercontent.com/assets/595023/13433117/7c77deea-df9e-11e5-9fbb-0e16402777c9.png)
