### PR TITLE
Enable non-admin users

### DIFF
--- a/server/rest/dataset.py
+++ b/server/rest/dataset.py
@@ -266,7 +266,7 @@ class Dataset(Resource):
     @access.public
     @loadmodel(map={'userId': 'user'}, model='user', level=AccessType.READ)
     def getDatasetFolder(self, user, params):
-        folder = findDatasetFolder(self.getCurrentUser(), user)
+        folder = findDatasetFolder(self.getCurrentUser(), user, create=True)
         return {'folder': folder}
     getDatasetFolder.description = (
         Description('Get the minerva dataset folder owned by a user.')

--- a/server/rest/session.py
+++ b/server/rest/session.py
@@ -66,7 +66,7 @@ class Session(Resource):
     @access.public
     @loadmodel(map={'userId': 'user'}, model='user', level=AccessType.READ)
     def getSessionFolder(self, user, params):
-        folder = findSessionFolder(self.getCurrentUser(), user)
+        folder = findSessionFolder(self.getCurrentUser(), user, create=True)
         return {'folder': folder}
     getSessionFolder.description = (
         Description('Get the minerva session folder owned by a user.')

--- a/server/rest/source.py
+++ b/server/rest/source.py
@@ -76,7 +76,7 @@ class Source(Resource):
     @access.public
     @loadmodel(map={'userId': 'user'}, model='user', level=AccessType.READ)
     def getSourceFolder(self, user, params):
-        folder = findSourceFolder(self.getCurrentUser(), user)
+        folder = findSourceFolder(self.getCurrentUser(), user, create=True)
         return {'folder': folder}
     getSourceFolder.description = (
         Description('Get the minerva source folder owned by a user.')

--- a/server/utility/minerva_utility.py
+++ b/server/utility/minerva_utility.py
@@ -25,13 +25,14 @@ from girder.plugins.minerva.constants import PluginSettings
 
 def findNamedFolder(currentUser, user, parent, parentType, name, create=False,
                     public=False):
-    folders = list(ModelImporter.model('folder').childFolders(
-            parent=parent, parentType=parentType, user=currentUser,
-            filters={'name': name}))
+    folders = \
+        [ModelImporter.model('folder').filter(folder, currentUser) for folder in
+         ModelImporter.model('folder').childFolders(parent=parent,
+         parentType=parentType, user=currentUser, filters={'name': name})]
     # folders should have len of 0 or 1, since we are looking in a
     # user folder for a folder with a certain name
     if len(folders) == 0:
-        if create:
+        if create and currentUser:
             folder = ModelImporter.model('folder').createFolder(
                 parent, name, parentType=parentType, public=public,
                 creator=currentUser)

--- a/server/utility/minerva_utility.py
+++ b/server/utility/minerva_utility.py
@@ -23,18 +23,19 @@ from girder.utility.model_importer import ModelImporter
 from girder.plugins.minerva.constants import PluginSettings
 
 
-def findNamedFolder(currentUser, user, parent, parentType, name, create=False):
-    folders = [
-        ModelImporter.model('folder').filter(folder, currentUser) for folder in
-        ModelImporter.model('folder').childFolders(
+def findNamedFolder(currentUser, user, parent, parentType, name, create=False,
+                    public=False):
+    folders = list(ModelImporter.model('folder').childFolders(
             parent=parent, parentType=parentType, user=currentUser,
-            filters={'name': name})]
+            filters={'name': name}))
     # folders should have len of 0 or 1, since we are looking in a
     # user folder for a folder with a certain name
     if len(folders) == 0:
         if create:
-            return ModelImporter.model('folder').createFolder(
-                parent, name, parentType=parentType, public=False)
+            folder = ModelImporter.model('folder').createFolder(
+                parent, name, parentType=parentType, public=public,
+                creator=currentUser)
+            return folder
         else:
             return None
     else:
@@ -101,7 +102,7 @@ def findAnalysisFolder(currentUser, create=False):
     else:
         analysisFolder = findNamedFolder(currentUser, currentUser,
                                          minervaCollection, 'collection',
-                                         'analysis', create)
+                                         'analysis', create, public=True)
         return analysisFolder
 
 

--- a/web_external/js/views/body/SessionsView.js
+++ b/web_external/js/views/body/SessionsView.js
@@ -46,7 +46,7 @@ minerva.views.SessionsView = minerva.View.extend({
     render: function () {
         this.$el.html(minerva.templates.sessionList({
             sessions: this.collection.models,
-            admin: !!(girder.currentUser && girder.currentUser.get('admin'))
+            currentUser: !!girder.currentUser
         }));
 
         this.paginateWidget.setElement(this.$('.m-session-pagination')).render();

--- a/web_external/stylesheets/body/sessionList.styl
+++ b/web_external/stylesheets/body/sessionList.styl
@@ -1,4 +1,5 @@
 .m-session-list-header
+  margin-top $headerHeight
   padding-bottom 10px
 
   .m-session-pagination

--- a/web_external/templates/body/sessionList.jade
+++ b/web_external/templates/body/sessionList.jade
@@ -1,17 +1,17 @@
-.m-session-list-header
-  .m-session-pagination
-  form.m-session-search-form.form-inline(role="form")
-    .form-group.m-sessions-search-container
+if (currentUser)
+    .m-session-list-header
+      .m-session-pagination
+      form.m-session-search-form.form-inline(role="form")
+        .form-group.m-sessions-search-container
 
-  if (admin)
-    button.m-session-create-button.btn.btn-sm.btn-default
-      i.icon-plus-squared
-      |  New session
+      button.m-session-create-button.btn.btn-sm.btn-default
+        i.icon-plus-squared
+        |  New session
 
-each session in sessions
-  .m-session-list-entry
-    .m-session-right-column
-    .m-session-title
-      a.m-session-link(m-session-cid="#{session.cid}")= session.get('name')
-    .m-session-description= session.get('description')
-    .g-clear-right
+    each session in sessions
+      .m-session-list-entry
+        .m-session-right-column
+        .m-session-title
+          a.m-session-link(m-session-cid="#{session.cid}")= session.get('name')
+        .m-session-description= session.get('description')
+        .g-clear-right


### PR DESCRIPTION
This allows Girder non-admin users to use Minerva.  I don't like that it makes changes on a GET request (really would just be the first time certain folders are needed and then created), but I can live with that.

We still have the sessions page be the first page the user sees, as it will take some thought as to how to remove this page and deal with what to show on the map page when a user isn't logged in.  At least once the user logs in and navigates to an individual session, they can do everything they need to on that session page (including switching sessions and creating new sessions).

Fixes #165, #71.

![screen shot 2016-04-07 at 3 33 52 pm](https://cloud.githubusercontent.com/assets/595023/14364630/ab05859a-fcd7-11e5-8a2c-98943a215f41.png)
