### PR TITLE
Mock wms endpoint for wms auth test

### DIFF
--- a/plugin_tests/wms_test.py
+++ b/plugin_tests/wms_test.py
@@ -153,20 +153,22 @@ class WmsTestCase(base.TestCase):
         """
         # Create the source.
         path = '/minerva_source_wms'
-        name = 'testWMSAuth'
-        username = 'admin'
-        password = 'admin'
-        baseURL = 'http://demo.geonode.org/geoserver/wms'
+        name = 'testWMS'
+        username = 'user'
+        password = 'password'
+        baseURL = 'http://fake.geoserver.fak/geoserver/ows'
         params = {
             'name': name,
             'username': username,
             'password': password,
             'baseURL': baseURL
         }
-        response = self.request(path=path, method='POST',
-                                params=params, user=self._user)
+
+        with HTTMock(wms_mock):
+            response = self.request(path=path, method='POST', params=params, user=self._user)
         self.assertStatusOk(response)
         wmsSource = response.json
+
         credentials = wmsSource['meta']['minerva']['wms_params']['credentials']
         # Make sure credentials were encrypted.
         self.assertNotEqual(credentials, '{}:{}'.format(username, password),


### PR DESCRIPTION
@kotfic PTAL

I (hopefully) fixed the failing wms test for you.  I mocked the call to the external WMS server, but the test is still valid, the important part is that the credentials were encrypted.

If you think this passes QA, feel free to merge it into master and/or your branch.  I'll be out of touch for the most part and won't be able to merge.