### PR TITLE
Fix positions of radio buttons and checkboxes.

### DIFF
--- a/web_external/templates/widgets/addMongoDatasetWidget.jade
+++ b/web_external/templates/widgets/addMongoDatasetWidget.jade
@@ -9,8 +9,8 @@
         each collection in mongo_collections
           .form-group
             .checkbox
-              input.m-add-collections(type="checkbox", name="#{collection}" mongo-collection="#{collection}")
               label
+                input.m-add-collections(type="checkbox", name="#{collection}" mongo-collection="#{collection}")
                 i.icon-layers.m-add-layers-type-icon
                 | #{collection}
       .modal-footer

--- a/web_external/templates/widgets/addSourceWidget.jade
+++ b/web_external/templates/widgets/addSourceWidget.jade
@@ -12,8 +12,8 @@
             .radio.m-add-source-radio
               - var id = 'm-' + sourceType + '-source'
               - var iconClasses = properties.icon + ' m-add-source-type-icon'
-              input(type="radio", id=id, name="m-source-add-method", checked=checked)
               label
+                input(type="radio", id=id, name="m-source-add-method", checked=checked)
                 i(class=iconClasses)
                 | #{properties.label}
               if checked === true

--- a/web_external/templates/widgets/layersListWidget.jade
+++ b/web_external/templates/widgets/layersListWidget.jade
@@ -1,6 +1,6 @@
 .form-group
   .checkbox.m-add-layers-checkbox
-    input.m-add-layers(type="checkbox", name="#{layer.layer_title}" typeName="#{layer.layer_type}", checked=checked, disabled=checked)
     label(class=checked ? 'm-disable-text' : '')
+      input.m-add-layers(type="checkbox", name="#{layer.layer_title}" typeName="#{layer.layer_type}", checked=checked, disabled=checked)
       i.icon-layers.m-add-layers-type-icon
       | #{layer.layer_title}


### PR DESCRIPTION
Bootstrap css expects radio and checkbox input elements to be children of label elements.  If they aren't, the checkbox or radio button is placed 20 pixels too far to the left.  In the dialogs, these are often on or beyond the left edge.