### PR TITLE
Fix checkboxes in the Wms Layers dialog.

### DIFF
--- a/web_external/js/views/widgets/WmsLayersListWidget.js
+++ b/web_external/js/views/widgets/WmsLayersListWidget.js
@@ -30,16 +30,6 @@ minerva.views.WmsLayersListWidget = minerva.View.extend({
                 }
             }, this));
         },
-
-        'click .m-add-layers-checkbox label': function (e) {
-            var checkbox = $(e.currentTarget).parent().find('input:checkbox').first();
-            var checked = checkbox.prop('checked');
-            var disabled = checkbox.prop('disabled');
-            if (!disabled) {
-                checkbox.prop('checked', !checked);
-            }
-        },
-
         'keyup #m-filter-layers': function (e) {
             var text = $(e.target).val();
             this.filterLayers(text);


### PR DESCRIPTION
In the previous PR, the layout of checkboxes was moved to the Bootstrap motif of including them as children of label elements.  Some code in the Wms layers dialog was then breaking functionality on the checkboxes in that clicking on a checkbox itself would "double" check it, resulting in no change.  This code was designed to prevent clicking labels from activating a disabled checkbox, but is no longer necessary.