### PR TITLE
Fix default tile layer attribution

### DIFF
--- a/web_external/js/models/SessionModel.js
+++ b/web_external/js/models/SessionModel.js
@@ -64,8 +64,8 @@ minerva.models.SessionModel = minerva.models.MinervaModel.extend({
         var map = {};
         map.basemap = 'osm';
         map.basemap_args = {
-            tileUrl: 'https://{s}.tiles.mapbox.com/v3/datamade.hn83a654/{z}/{x}/{y}.png',
-            attribution: '<a href=http://www.mapbox.com/about/maps/ target=_blank>Terms &amp; Feedback</a>'
+            url: 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+            attribution: 'Tile data &copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
         };
         map.center = {x: -100, y: 36.5};
         map.zoom = 4;


### PR DESCRIPTION
The tile url was not being set because it was using the wrong option name, so the OSM tile set was displayed with the mapbox attribution.  This fix will only work for newly created layers.

Also, the mapbox tiles look somewhat nicer, but the response rate is much slower than the OSM server, so I think OSM makes for a better default.