### PR TITLE
Set an arbitrary Girder item as a Minerva GeoJSON dataset

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -162,7 +162,7 @@ module.exports = function (grunt) {
                     {
                         expand: true,
                         cwd: '<%= plugin.minerva.geojs %>',
-                        src: ['geo.min.js'],
+                        src: ['geo.js'],
                         dest: '<%= plugin.minerva.static %>'
                     }
                 ]
@@ -225,7 +225,7 @@ module.exports = function (grunt) {
                 files: {
                     '<%= plugin.minerva.static %>/minerva.ext.min.js':
                     [
-                        '<%= plugin.minerva.static %>/geo.min.js',
+                        '<%= plugin.minerva.static %>/geo.js',
                         '<%= plugin.minerva.static %>/jsonpath.min.js',
                         '<%= plugin.minerva.static %>/papaparse.min.js',
                         '<%= plugin.minerva.static %>/colorbrewer.min.js',
@@ -294,7 +294,7 @@ module.exports = function (grunt) {
             },
             'plugin-minerva-copy-geojs': {
                 files: [
-                    '<%= plugin.minerva.geojs %>/geo.min.js'
+                    '<%= plugin.minerva.geojs %>/geo.js'
                 ],
                 tasks: ['copy:geojs']
             }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "bootstrap-select": "^1.10.0",
     "bootstrap-slider": "^7.1.0",
     "colorbrewer": "1.0.0",
-    "geojs": "0.9.0",
+    "geojs": "0.10.1",
     "jade": "~1.11.0",
     "jquery-ui-bundle": "^1.11.4",
     "underscore": "~1.5"

--- a/server/rest/geojson_dataset.py
+++ b/server/rest/geojson_dataset.py
@@ -50,11 +50,20 @@ class GeojsonDataset(Dataset):
         }
         # Use the first geojson or json file found as the dataset.
         for file in self.model('item').childFiles(item=item, limit=0):
-            if 'geojson' in file['exts'] or 'json' in file['exts']:
+            if ('geojson' in file['exts'] or 'json' in file['exts'] or
+                    file.get('mimeType') in (
+                        'application/json', 'application/vnd.geo+json',
+                    )):
                 minerva_metadata['original_files'] = [{
                     'name': file['name'], '_id': file['_id']}]
                 minerva_metadata['geojson_file'] = {
                     'name': file['name'], '_id': file['_id']}
+                minerva_metadata['geo_render'] = {
+                    'type': 'geojson', 'file_id': file['_id']}
+                minerva_metadata['original_type'] = 'geojson'
+                minerva_metadata['source'] = {
+                    'layer_source': 'GeoJSON'}
+                minerva_metadata['source_type'] = 'item'
                 break
         if 'geojson_file' not in minerva_metadata:
             raise RestException('Item contains no geojson file.')

--- a/web_client/js/fileList.js
+++ b/web_client/js/fileList.js
@@ -1,0 +1,57 @@
+girder.wrap(girder.views.FileListWidget, 'render', function (render) {
+    render.call(this);
+    if (!this.parentItem || !this.parentItem.get('_id')) {
+        return this;
+    }
+    if (this.parentItem.getAccessLevel() < girder.AccessType.WRITE) {
+        return this;
+    }
+    var minerva = (this.parentItem.get('meta') || {}).minerva;
+    var files = this.collection.toArray();
+    _.each(files, function (file) {
+        var isMinervaGeojson = ((minerva || {}).geojson_file || {})._id === file.id;
+        if (!minerva && $.inArray(file.get('mimeType'), ['application/json', 'application/vnd.geo+json']) < 0 && !file.get('name').match(/\.(geojson|json)(\.|$)/i)) {
+            return;
+        }
+        var actions = $('.g-file-list-link[cid="' + file.cid + '"]',
+                        this.$el).closest('.g-file-list-entry').children(
+                        '.g-file-actions-container');
+        if (!actions.length) {
+            return;
+        }
+        var fileAction = girder.templates.minerva_fileAction({
+            file: file, minerva: minerva, geojson: isMinervaGeojson});
+        if (fileAction) {
+            actions.prepend(fileAction);
+        }
+    });
+    $('.g-minerva-geojson-remove', this.$el).on('click', _.bind(function () {
+        this.parentItem.removeMetadata('minerva', _.bind(function () {
+            this.parentItem.unset('meta');
+            this.parentItem.fetch();
+        }, this));
+    }, this));
+    $('.g-minerva-geojson-create', this.$el).on('click', _.bind(function (e) {
+        var cid = $(e.currentTarget).parent().attr('file-cid');
+        var fileId = this.collection.get(cid).id;
+        girder.restRequest({
+            type: 'POST',
+            path: 'minerva_dataset_geojson',
+            data: {itemId: this.parentItem.id},
+            error: function (error) {
+                if (error.status !== 0) {
+                    girder.events.trigger('g:alert', {
+                        text: error.responseJSON.message,
+                        type: 'info',
+                        timeout: 5000,
+                        icon: 'info'
+                    });
+                }
+            }
+        }).done(_.bind(function () {
+            this.parentItem.unset('meta');
+            this.parentItem.fetch();
+        }, this));
+    }, this));
+    return this;
+});

--- a/web_client/stylesheets/fileList.styl
+++ b/web_client/stylesheets/fileList.styl
@@ -1,0 +1,13 @@
+span.fa-stack
+  position relative
+  i
+    position absolute
+    left 0
+    top 0
+  i:first-child
+    position relative
+  i.fa-cancel-cover
+    font-size 75%
+    left 40%
+    top -30%
+    color red

--- a/web_client/templates/minerva_fileAction.jade
+++ b/web_client/templates/minerva_fileAction.jade
@@ -1,0 +1,8 @@
+if geojson
+  a.g-minerva-geojson-remove(title="Stop using this file for a Minerva GeoJSON datset")
+    span.fa-stack
+      i.icon-globe
+      i.icon-cancel.fa-cancel-cover
+else if !minerva
+  a.g-minerva-geojson-create(title="Use this file for a Minerva GeoJSON dataset")
+    i.icon-globe

--- a/web_external/js/models/DatasetModel.js
+++ b/web_external/js/models/DatasetModel.js
@@ -139,6 +139,9 @@ minerva.models.DatasetModel = minerva.models.MinervaModel.extend({
      */
     getGeoRenderType: function () {
         var mm = this.metadata();
+        if (!mm) {
+            return null;
+        }
         if (!mm.geo_render) {
             this._initGeoRender();
         }
@@ -204,6 +207,9 @@ minerva.models.DatasetModel = minerva.models.MinervaModel.extend({
     loadTabularData: function () {
         // TODO looks similar enough to loadGeoData, consider unification.
         var mm = this.metadata();
+        if (!mm) {
+            return;
+        }
         if (this.get('tableData') !== null) {
             this.trigger('m:dataset_table_dataLoaded', this);
         } else {

--- a/web_external/js/models/SessionModel.js
+++ b/web_external/js/models/SessionModel.js
@@ -64,8 +64,8 @@ minerva.models.SessionModel = minerva.models.MinervaModel.extend({
         var map = {};
         map.basemap = 'osm';
         map.basemap_args = {
-            tileUrl: 'https://{s}.tiles.mapbox.com/v3/datamade.hn83a654/{z}/{x}/{y}.png',
-            attribution: '<a href=http://www.mapbox.com/about/maps/ target=_blank>Terms &amp; Feedback</a>'
+            url: 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+            attribution: 'Tile data &copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
         };
         map.center = {x: -100, y: 36.5};
         map.zoom = 4;

--- a/web_external/js/views/body/DataPanel.js
+++ b/web_external/js/views/body/DataPanel.js
@@ -219,12 +219,12 @@ minerva.views.DataPanel = minerva.views.Panel.extend({
     },
 
     getSourceNameFromModel: function (model) {
-        return model.get('meta').minerva.source.layer_source;
+        return (((model.get('meta') || {}).minerva || {}).source || {}).layer_source;
     },
 
     render: function () {
         this.sourceDataset = _.groupBy(
-            this.collection.models,
+            _.filter(this.collection.models, this.getSourceNameFromModel),
             this.getSourceNameFromModel
         );
 

--- a/web_external/js/views/map/MapPanel.js
+++ b/web_external/js/views/map/MapPanel.js
@@ -143,6 +143,9 @@ minerva.views.MapPanel = minerva.views.Panel.extend({
      * @param {Object} visProperties - Properties used to render the dataset as a layerType
      */
     addDataset: function (dataset, layerType, visProperties) {
+        if (!dataset.metadata()) {
+            return;
+        }
         var datasetId = dataset.get('_id');
 
         if (!_.contains(this.datasetLayerReprs, datasetId)) {

--- a/web_external/stylesheets/layout.styl
+++ b/web_external/stylesheets/layout.styl
@@ -77,12 +77,13 @@ $leftColWidth = 280px
       &:active
         background linear-gradient(bottom, white 60%, #f6f6f6 100%)
 
-#g-app-body-container
+#g-app-body-container.minerva-app
   position relative
   width 100%
   height 100%
   margin 0
   padding 0
+  overflow hidden
 
 html, body
   height 100%

--- a/web_external/templates/layout.jade
+++ b/web_external/templates/layout.jade
@@ -1,5 +1,5 @@
 #m-app-header-container
-#g-app-body-container
+#g-app-body-container.minerva-app
 #m-app-footer-container
 
 #g-app-progress-container


### PR DESCRIPTION
Rather than require the item to be uploaded, it can be marked via the POST minerva_dataset_geojson endpoint.

Added a globe icon to the Girder file list to call the endpoint for a specific file within an item.  When a file is used as a Minerva dataset, a globe with an x is shown, clicking which removes the minerva metadata.

If a dataset that is in use in a session is unmarked (by having the minerva metadata tag removed), don't throw javascript exceptions.

The POST endpoint didn't set all of the metadata that was required for sources, etc.  This has been changed, but has not been tested to make sure it doesn't have ill repercussions.

Fixed some CSS that caused Girder to look poorly and require horizontal scrolling.  Also fixed an issue when the main Minerva body would show a vertical scrollbar.


This PR also merged the changes on master.