### PR TITLE
Collection geojson properties on click

### DIFF
--- a/web_external/js/views/adapters/Adapters.js
+++ b/web_external/js/views/adapters/Adapters.js
@@ -159,11 +159,11 @@ minerva.rendering.geo.GeometryRepresentation = minerva.rendering.geo.defineMapLa
         var _createFeature = this.geoJsLayer.createFeature;
         this.geoJsLayer.createFeature = function (name, arg) {
             if (!arg) {
-                arg = {}
+                arg = {};
             }
             arg.selectionAPI = true;
             return _createFeature.call(this, name, arg);
-        }
+        };
 
         this._injectStyle(data, visProperties, data.summary || {});
         try {

--- a/web_external/js/views/adapters/Adapters.js
+++ b/web_external/js/views/adapters/Adapters.js
@@ -153,6 +153,7 @@ minerva.rendering.geo.GeometryRepresentation = minerva.rendering.geo.defineMapLa
      */
     this.init = function (container, dataset, visProperties, data) {
         this.geoJsLayer = container.createLayer('feature');
+        dataset.geoJsLayer = this.geoJsLayer;
 
         // force selection api on all features for this layer
         var _createFeature = this.geoJsLayer.createFeature;

--- a/web_external/js/views/adapters/Adapters.js
+++ b/web_external/js/views/adapters/Adapters.js
@@ -153,6 +153,17 @@ minerva.rendering.geo.GeometryRepresentation = minerva.rendering.geo.defineMapLa
      */
     this.init = function (container, dataset, visProperties, data) {
         this.geoJsLayer = container.createLayer('feature');
+
+        // force selection api on all features for this layer
+        var _createFeature = this.geoJsLayer.createFeature;
+        this.geoJsLayer.createFeature = function (name, arg) {
+            if (!arg) {
+                arg = {}
+            }
+            arg.selectionAPI = true;
+            return _createFeature.call(this, name, arg);
+        }
+
         this._injectStyle(data, visProperties, data.summary || {});
         try {
             var reader = geo.createFileReader(this.readerType, {layer: this.geoJsLayer});

--- a/web_external/js/views/widgets/WMSFeatureInfoWidget.js
+++ b/web_external/js/views/widgets/WMSFeatureInfoWidget.js
@@ -15,12 +15,17 @@ minerva.views.WmsFeatureInfoWidget = minerva.View.extend({
             _.chain(that.parentView.collection.models)
                 .filter(function (set) { return set.get('displayed') && set.getDatasetType() === 'geojson'; })
                 .map(function (dataset) {
+                    var i;
                     var layer = {};
                     var features = dataset.geoJsLayer.features();
                     _.each(features, function (feature) {
                         var hits = feature.pointSearch(event.geo);
-                        if (hits && hits.found.length !== 0) {
-                            layer['properties'] = hits.found[0].properties;
+                        if (hits && hits.found) {
+                            for (i = hits.found.length - 1; i >= 0; i -= 1) {
+                                if (hits.found[i].properties) {
+                                    layer['properties'] = hits.found[i].properties;
+                                }
+                            }
                         }
                     });
                     layer['id'] = dataset.get('name');

--- a/web_external/js/views/widgets/WMSFeatureInfoWidget.js
+++ b/web_external/js/views/widgets/WMSFeatureInfoWidget.js
@@ -129,7 +129,7 @@ minerva.views.WmsFeatureInfoWidget = minerva.View.extend({
     renderContents: function (inspectResp) {
         $('#m-wms-info-dialog').html(
             minerva.templates.wmsFeatureInfoContent({
-                contents: inspectResp
+                layersInfo: inspectResp
             })
         );
         if (inspectResp.length !== 0) {

--- a/web_external/js/views/widgets/WMSFeatureInfoWidget.js
+++ b/web_external/js/views/widgets/WMSFeatureInfoWidget.js
@@ -7,9 +7,11 @@ minerva.views.WmsFeatureInfoWidget = minerva.View.extend({
             .map(function (dataset) { return dataset.get('_id'); })
             .value();
 
-        var geojsonProperties = _.chain(this.parentView.collection.models)
+        var geojsonLayers = [];
+        _.chain(this.parentView.collection.models)
             .filter(function (set) { return set.get('displayed') && set.getDatasetType() === 'geojson'; })
             .map(function (dataset) {
+                var layer = {};
                 var features = dataset.geoJsLayer.features();
                 var props = [];
                 _.each(features, function (feature) {
@@ -18,12 +20,10 @@ minerva.views.WmsFeatureInfoWidget = minerva.View.extend({
                         props.push.apply(props, _.pluck(hits.found, 'properties'));
                     }
                 });
-                return props;
+                layer['id'] = dataset.get('name');
+                layer['properties'] = props;
+                geojsonLayers.push(layer);
             })
-            .flatten(true)
-            .value();
-
-        console.log(geojsonProperties);
 
         var coord = event.geo;
         var pnt = this.map.gcsToDisplay(coord);

--- a/web_external/js/views/widgets/WMSFeatureInfoWidget.js
+++ b/web_external/js/views/widgets/WMSFeatureInfoWidget.js
@@ -7,6 +7,24 @@ minerva.views.WmsFeatureInfoWidget = minerva.View.extend({
             .map(function (dataset) { return dataset.get('_id'); })
             .value();
 
+        var geojsonProperties = _.chain(this.parentView.collection.models)
+            .filter(function (set) { return set.get('displayed') && set.getDatasetType() === 'geojson'; })
+            .map(function (dataset) {
+                var features = dataset.geoJsLayer.features();
+                var props = [];
+                _.each(features, function (feature) {
+                    var hits = feature.pointSearch(event.geo);
+                    if (hits && hits.found) {
+                        props.push.apply(props, _.pluck(hits.found, 'properties'));
+                    }
+                });
+                return props;
+            })
+            .flatten(true)
+            .value();
+
+        console.log(geojsonProperties);
+
         var coord = event.geo;
         var pnt = this.map.gcsToDisplay(coord);
 

--- a/web_external/templates/widgets/wmsFeatureInfoContent.jade
+++ b/web_external/templates/widgets/wmsFeatureInfoContent.jade
@@ -1,0 +1,1 @@
+h1 Hooray

--- a/web_external/templates/widgets/wmsFeatureInfoContent.jade
+++ b/web_external/templates/widgets/wmsFeatureInfoContent.jade
@@ -1,1 +1,13 @@
-h4 #{layersInfo}
+if layersInfo
+  each layer in layersInfo
+    h4= layer.id
+    .accordion
+      div
+        table
+          tbody
+            tr(class="header")
+              each value, key in layer.properties
+                td= key
+            tr(class="even")
+              each value, key in layer.properties
+                td= value

--- a/web_external/templates/widgets/wmsFeatureInfoContent.jade
+++ b/web_external/templates/widgets/wmsFeatureInfoContent.jade
@@ -1,1 +1,1 @@
-h1 Hooray
+h4 #{layersInfo}


### PR DESCRIPTION
@dorukozturk This is about half the work required to get geojson property information to display on click.  There are two blocks of code here:

1. Enables the selection api on geojson feature layers with some hackery that is necessary until https://github.com/OpenGeoscience/geojs/pull/649 shows up in a release.
2. Connects to the existing click handler to call the `pointSearch` method on all features created for the dataset.  Because all of data is assumed to be geojson, getting the properties is straightforward.  After the underscore pipeline, I just print out the property array to the console.

What I'm leaving for you is merging these property objects with those returned from the REST API for WMS layers [further down](https://github.com/Kitware/minerva/compare/select-geojson?expand=1#diff-b32150086f8ccbc039b4d05197312c6cR70) in the function.  Let me know if you have any questions.