### PR TITLE
Don't append feature properties if no hits were found

### DIFF
--- a/web_external/js/views/widgets/WMSFeatureInfoWidget.js
+++ b/web_external/js/views/widgets/WMSFeatureInfoWidget.js
@@ -28,8 +28,10 @@ minerva.views.WmsFeatureInfoWidget = minerva.View.extend({
                             }
                         }
                     });
-                    layer['id'] = dataset.get('name');
-                    geojsonLayers.push(layer);
+                    if (layer.properties) {
+                        layer['id'] = dataset.get('name');
+                        geojsonLayers.push(layer);
+                    }
                     return geojsonLayers;
                 });
 


### PR DESCRIPTION
@dorukozturk This should fix the bug in clicking on geojson layers that we noticed yesterday.