### PR TITLE
Remove BSVE root url code from minerva

### DIFF
--- a/server/rest/feature.py
+++ b/server/rest/feature.py
@@ -59,11 +59,9 @@ class FeatureInfo(Resource):
 
         layerSource = []
 
-        bsveurl = 'https://api-dev.bsvecosystem.net/data/v2/sources/' \
-                  'geotiles/data/result'
         for i in activeLayers:
             item = self._getMinervaItem(i)
-            url = item['meta']['minerva'].get('base_url', bsveurl)
+            url = item['meta']['minerva'].get('base_url')
             layerSource.append((url, item['meta']['minerva']['type_name']))
 
         layerUrlMap = defaultdict(list)


### PR DESCRIPTION
This code is unnecessary as the geoviz plugin computes the base url itself.