### PR TITLE
Fixes the layer mix matching issue

### DIFF
--- a/web_external/js/views/adapters/Adapters.js
+++ b/web_external/js/views/adapters/Adapters.js
@@ -55,16 +55,16 @@ function generate_sequence(start, stop, count) {
         this._createRepresentation = function (container, dataset, layerType, visProperties) {
             if (layerType === null || !_.has(this.registry, layerType)) {
                 console.error('This dataset cannot be adapted to a map layer of type [' + layerType + '].');
-                this.trigger('m:map_adapter_error', dataset, layerType);
+                dataset.trigger('m:map_adapter_error', dataset, layerType);
                 return;
             } else {
                 var Adapter = this.registry[layerType];
                 var layerRepr = _.extend(new Adapter(), Backbone.Events);
                 dataset.once('m:dataset_geo_dataLoaded', function () {
                     layerRepr.once('m:map_layer_renderable', function (layer) {
-                        this.trigger('m:map_adapter_layerCreated', layer);
+                        dataset.trigger('m:map_adapter_layerCreated', layer);
                     }, this).once('m:map_layer_error', function (layer) {
-                        this.trigger('m:map_adapter_layerError', layer);
+                        dataset.trigger('m:map_adapter_layerError', layer);
                     }, this).init(container, dataset, visProperties, dataset.get('geoData'));
                 }, this).loadGeoData();
                 //

--- a/web_external/js/views/map/MapPanel.js
+++ b/web_external/js/views/map/MapPanel.js
@@ -160,7 +160,7 @@ minerva.views.MapPanel = minerva.views.Panel.extend({
                 visProperties = (dataset.getMinervaMetadata() || {}).visProperties || {};
             }
 
-            minerva.core.AdapterRegistry.once('m:map_adapter_layerCreated', function (repr) {
+            dataset.once('m:map_adapter_layerCreated', function (repr) {
                 this.datasetLayerReprs[datasetId] = repr;
                 repr.render(this);
             }, this).once('m:map_adapter_error', function (dataset, layerType) {
@@ -170,7 +170,8 @@ minerva.views.MapPanel = minerva.views.Panel.extend({
                     repr.delete(this);
                     dataset.set('geoError', true);
                 }
-            }, this)._createRepresentation(this, dataset, layerType, visProperties);
+            }, this);
+            minerva.core.AdapterRegistry._createRepresentation(this, dataset, layerType, visProperties);
         }
     },
 


### PR DESCRIPTION
This PR aim to fix the issue https://github.com/Kitware/minerva/issues/398

The related events were associated with a singleton object and event is triggered in an async callback, making three different handlers being triggered by one event. However, the code is intended to have three event handler trigger by three different events. 
This PR move events onto individual datasets.