### PR TITLE
Two styling related fixes

### DIFF
--- a/web_external/js/views/widgets/GeoJSONStyleWidget.js
+++ b/web_external/js/views/widgets/GeoJSONStyleWidget.js
@@ -9,11 +9,11 @@
             radius: 8,
             stroke: true,
             strokeWidth: 2,
-            strokeColor: '#000000',
+            strokeColor: '#999999',
             strokeOpacity: 1,
             fill: true,
             fillOpacity: 0.75,
-            fillColor: '#ff0000',
+            fillColor: '#BEE37B',
             strokeRamp: 'Blues',
             strokeColorKey: null,
             fillRamp: 'Reds',
@@ -228,7 +228,7 @@ minerva.views.GeoJSONStyleWidget = minerva.View.extend({
     },
     _getTabs: function (data) {
         var points = !!minerva.geojson.getFeatures(data, 'Point', 'MultiPoint').length;
-        var lines = !!minerva.geojson.getFeatures(data, 'Line', 'MultiLine').length;
+        var lines = !!minerva.geojson.getFeatures(data, 'LineString', 'MultiLineString').length;
         var polygons = !!minerva.geojson.getFeatures(data, 'Polygon', 'MultiPolygon').length;
         var tabs = {};
 


### PR DESCRIPTION
This PR fixes two issues,

1, The previous Postgres feature applies a default style to geometries because we would like to have initial `fillColorKey` value, this also fixes the behavior that the initial styling on the map and the styling on the styling modal doesn't match. However, that change has an issue that the default styling won't be applied at first rendering to geojson that doesn't have style. 

2, The GeojsonStyleWidget had an issue that it won't recognize geojson LineString becuase it is looking for the style `Line` instead of `LineString`. 