### PR TITLE
Dataset download api endpoint

### DIFF
--- a/server/rest/postgres_geojson.py
+++ b/server/rest/postgres_geojson.py
@@ -3,8 +3,7 @@ import json
 
 from girder.api import access
 from girder.api.describe import describeRoute, Description
-from girder.constants import AccessType
-from girder.api.rest import Resource, ValidationException, loadmodel, GirderException
+from girder.api.rest import Resource, ValidationException, loadmodel
 from girder.utility import assetstore_utilities, progress
 from girder.plugins.minerva.rest.geojson_dataset import GeojsonDataset
 from girder.plugins.minerva.utility.minerva_utility import findDatasetFolder
@@ -22,7 +21,6 @@ class PostgresGeojson(Resource):
         self.route('POST', (), self.createPostgresGeojsonData)
         self.route('GET', ('geometrylink', ), self.getGeometryLinkTarget)
         self.route('GET', ('geometrylinkfields', ), self.geometryLinkField)
-        self.route('GET', (':id',), self.getPostgresGeojsonData)
 
     def _getDbName(self):
         assetstores = self.model('assetstore').list(limit=10)
@@ -277,79 +275,3 @@ class PostgresGeojson(Resource):
                 'properties' not in featureCollections['features'][0]:
             raise ValidationException('invalid geojson file')
         return featureCollections['features'][0]['properties'].keys()
-
-    @access.user
-    @loadmodel(model='item', level=AccessType.READ)
-    @describeRoute(
-        Description("Get linked geojson dataset.")
-        .param('id', 'The ID of the item.', paramType='path')
-        .errorResponse('ID was invalid.')
-        .errorResponse('Dataset linking failed', 500)
-        .errorResponse('Dataset is empty', 500)
-    )
-    def getPostgresGeojsonData(self, item, params):
-        user = self.getCurrentUser()
-        file = self.model('file').load(item['meta']['minerva'][
-            'original_files'][0]['_id'], user=user)
-        assetstore = self.model('assetstore').load(file['assetstoreId'])
-        adapter = assetstore_utilities.getAssetstoreAdapter(assetstore)
-        func = adapter.downloadFile(
-            file, offset=0, headers=False, endByte=None,
-            contentDisposition=None, extraParameters=None)
-
-        geometryField = item['meta']['minerva']['postgresGeojson']['geometryField']
-
-        if geometryField['type'] == 'built-in':
-            return func
-        elif geometryField['type'] == 'link':
-            featureCollections = None
-            records = json.loads(''.join(list(func())))
-            try:
-                item = self.model('item').load(geometryField['itemId'], force=True)
-                file = list(self.model('item').childFiles(item=item, limit=1))[0]
-                assetstore = self.model('assetstore').load(file['assetstoreId'])
-                adapter = assetstore_utilities.getAssetstoreAdapter(assetstore)
-                func = adapter.downloadFile(
-                    file, offset=0, headers=False, endByte=None,
-                    contentDisposition=None, extraParameters=None)
-            except Exception:
-                raise GirderException('Unable to load link target dataset.')
-            featureCollections = json.loads(''.join(list(func())))
-
-            valueLinks = sorted([x for x in geometryField['links']
-                                 if x['operator'] == '='])
-            constantLinks = [x for x in geometryField['links']
-                             if x['operator'] == 'constant']
-            mappedGeometries = {}
-            for feature in featureCollections['features']:
-                skip = False
-                for constantLink in constantLinks:
-                    if feature['properties'][constantLink['field']] != constantLink['value']:
-                        skip = True
-                        break
-                if skip:
-                    continue
-                try:
-                    key = ''.join([feature['properties'][x['field']] for x in valueLinks])
-                except KeyError:
-                    raise GirderException('missing property for key ' +
-                                          x['field'] + ' in geometry link target geojson')
-                mappedGeometries[key] = feature['geometry']
-
-            assembled = []
-            for record in records:
-                key = ''.join([record[x['value']] for x in valueLinks])
-                if key in mappedGeometries:
-                    assembled.append({
-                        'type': 'Feature',
-                        'geometry': mappedGeometries[key],
-                        'properties': record
-                    })
-
-            if len(assembled) == 0:
-                raise GirderException('Dataset is empty')
-
-            return {
-                'type': 'FeatureCollection',
-                'features': assembled
-            }

--- a/web_external/models/DatasetModel.js
+++ b/web_external/models/DatasetModel.js
@@ -200,18 +200,8 @@ const DatasetModel = MinervaModel.extend({
                 this.set('geoData', mm.geojson.data);
             }
             this.trigger('m:dataset_geo_dataLoaded', this);
-        } else if (mm.postgresGeojson) {
-            restRequest({
-                path: '/minerva_postgres_geojson/' + this.get('_id'),
-                contentType: 'application/json',
-                dataType: null
-            })
-                .done(_.bind(function (data) {
-                    this.set('geoData', data);
-                    this.trigger('m:dataset_geo_dataLoaded', this);
-                }, this));
         } else {
-            var path = '/file/' + mm.geo_render.file_id + '/download';
+            var path = '/minerva_dataset/' + this.get('_id') + '/download';
             restRequest({
                 path: path,
                 contentType: 'application/json',


### PR DESCRIPTION
Minerva core and it's dependent like [gaia minerva](https://github.com/OpenDataAnalytics/gaia_minerva) are using girder file download API endpoint to get the data of Minerva Dataset. 
However, with the introduction of Postgres on-the-fly geometry linking dataset, the existing girder file download API is not supporting downloading of such dataset because the data needs on-the-fly processing.
We should unify the downloading interface of all Minerva dataset. Monkey patching file/download api is cumbersome and error prone. Also, as Minerva dataset are getting more complex, it makes sense to build Minerva Dataset specific API instead of work around girder concepts. 
So, this PR creates minerva_dataset/download API to replace the role of file/download endpoint. This new endpoint output geojson download no matter it is a GeoJSON dataset or Postgres geometry linking dataset. 