### PR TITLE
Fixes issues with layer reordering

### DIFF
--- a/web_external/views/body/LayersPanel.js
+++ b/web_external/views/body/LayersPanel.js
@@ -70,45 +70,51 @@ const LayersPanel = Panel.extend({
     },
 
     reorderLayer: function (event) {
-        var prevDataset, nextDataset;
-        var datasetId = $(event.currentTarget).attr('m-dataset-id');
         var option = $(event.currentTarget).attr('m-order-option');
-        var dataset = this.collection.get(datasetId);
+        var dataset = this.collection.get($(event.currentTarget).attr('m-dataset-id'));
 
         var displayedDatasets = _.filter(this.collection.models, function (set) {
             return set.get('displayed');
         });
-        var currentDatasetIndex = _.indexOf(displayedDatasets, dataset);
 
-        if (displayedDatasets[currentDatasetIndex - 1]) {
-            prevDataset = displayedDatasets[currentDatasetIndex - 1];
+        if (option === 'moveDown' || option === 'moveUp') {
+            var swapDataset;
+            if (option === 'moveDown') {
+                swapDataset = _.chain(displayedDatasets)
+                    .sortBy(function (d) { return d.get('stack'); })
+                    .reverse()
+                    .find(function (d) { return d.get('stack') < dataset.get('stack'); })
+                    .value();
+            }
+            else {
+                swapDataset = _.chain(displayedDatasets)
+                    .sortBy(function (d) { return d.get('stack'); })
+                    .find(function (d) { return d.get('stack') > dataset.get('stack'); })
+                    .value();
+            }
+            if (swapDataset) {
+                var currentStack = dataset.get('stack');
+                dataset.set('stack', swapDataset.get('stack'));
+                swapDataset.set('stack', currentStack);
+                this.reorderDisplayedLayers(option, dataset);
+            }
         }
-
-        if (displayedDatasets[currentDatasetIndex + 1]) {
-            nextDataset = displayedDatasets[currentDatasetIndex + 1];
+        else if (option === 'moveToBottom' && dataset.get('stack') !== 1) {
+            _.chain(displayedDatasets)
+                .filter(function (d) { return d.get('stack') < dataset.get('stack') })
+                .each(function (dataset) { dataset.set('stack', dataset.get('stack') + 1); });
+            dataset.set('stack', 1);
+            this.reorderDisplayedLayers(option, dataset);
         }
-
-        var stackValues = _.invoke(displayedDatasets, 'get', 'stack');
-
-        var currentStack = dataset.get('stack');
-        // Retrieve the first and last stack value in the collection
-        var lastValueInStack = _.max(stackValues);
-        var firstValueInStack = _.min(stackValues);
-
-        if (option === 'moveToTop' && currentStack !== lastValueInStack) {
-            dataset.set('stack', lastValueInStack + 1);
-            this.reorderDisplayedLayers(option, dataset);
-        } else if (option === 'moveToBottom' && currentStack !== firstValueInStack) {
-            dataset.set('stack', firstValueInStack - 1);
-            this.reorderDisplayedLayers(option, dataset);
-        } else if (option === 'moveUp' && currentStack !== lastValueInStack) {
-            dataset.set('stack', currentStack + 1);
-            (nextDataset || prevDataset).set('stack', currentStack);
-            this.reorderDisplayedLayers(option, dataset);
-        } else if (option === 'moveDown' && (currentStack !== firstValueInStack)) {
-            dataset.set('stack', currentStack - 1);
-            (prevDataset || nextDataset).set('stack', currentStack);
-            this.reorderDisplayedLayers(option, dataset);
+        else if (option === 'moveToTop') {
+            var topStack = _.max(displayedDatasets, function (dataset) { return dataset.get('stack') }).get('stack');
+            if (dataset.get('stack') != topStack) {
+                _.chain(displayedDatasets)
+                    .filter(function (d) { return d.get('stack') > dataset.get('stack') })
+                    .each(function (dataset) { dataset.set('stack', dataset.get('stack') - 1); });
+                dataset.set('stack', topStack);
+                this.reorderDisplayedLayers(option, dataset);
+            }
         }
     },
 


### PR DESCRIPTION
This addresses the issue https://github.com/Kitware/minerva/issues/423.

This basically implements a new logic for calculation the 'stack' value of datasets when reordering.

Issue reproduce:
Add more than three datasets to session layer, reorder layer freely, the map and panel will start to behave unexpectedly.
![2017-07-12_15-07-50](https://user-images.githubusercontent.com/3123478/28166337-8469c9a2-67a5-11e7-9fd8-d88585704d7e.gif)

Fix result:
![2017-07-13_08-28-37](https://user-images.githubusercontent.com/3123478/28166345-8adb9770-67a5-11e7-81eb-44c3f283dd5c.gif)

Sample datasets:
(Any dataset will do, These three are provided for convinience. Rename .txt to .geojson before uploading)
[buffer.geojson.txt](https://github.com/Kitware/minerva/files/1145108/buffer.geojson.txt)
[intersect.geojson.txt](https://github.com/Kitware/minerva/files/1145109/intersect.geojson.txt)
[within.geojson.txt](https://github.com/Kitware/minerva/files/1145110/within.geojson.txt)

