### PR TITLE
Makes it ready to enable adding WMS layer

### DIFF
--- a/web_external/templates/body/dataPanel.pug
+++ b/web_external/templates/body/dataPanel.pug
@@ -2,6 +2,8 @@ include ../layout/panelMixins.pug
 
 +panel-title('Datasets', 'm-data-panel')
   i.m-upload-local.m-icon-enabled.icon-upload(title="Upload local file")
+  // uncomment this line to enable adding wms layer
+  //- i.m-add-wms.m-icon-enabled.icon-upload(title="Add WMS dataset")
   i.m-postgres.m-icon-enabled.icon-database(title="Connect to postgres")
 
 if sourceCategoryDataset

--- a/web_external/views/widgets/StyleWmsDatasetWidget.js
+++ b/web_external/views/widgets/StyleWmsDatasetWidget.js
@@ -182,7 +182,7 @@ import 'bootstrap-select/dist/css/bootstrap-select.css';
             });
         } else {
             attributes = this._get_attributes();
-            return styleWmsDatasetWidget({
+            return styleWmsDatasetWidgetTemplate({
                 attributes: attributes,
                 ramps: this.ramps
             });


### PR DESCRIPTION
The adding WMS layer button was disabled, but the functionality is kept in the code.
A code bug issue was introduced during girder 2 migration that preventing enable adding WMS layer.

This PR fixes the issue and make it easy to enable the WMS feature easily. 
