### PR TITLE
Style on layer

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "jade": "~1.11.0",
     "jquery-extendext": "^0.1.2",
     "jquery-ui-bundle": "^1.11.4",
-    "moment": "^2.17.1"
+    "moment": "^2.17.1",
+    "reconcile.js": "github:matthewma7/reconcile.js"
   },
   "devDependencies": {
     "grunt-contrib-watch": "^1.0.0"

--- a/server/rest/analysis.py
+++ b/server/rest/analysis.py
@@ -31,6 +31,7 @@ from girder.plugins.minerva.rest.dataset import Dataset
 
 class Analysis(Resource):
     def __init__(self):
+        super(Analysis, self).__init__()
         self.resourceName = 'minerva_analysis'
         self.route('GET', ('folder',), self.getAnalysisFolder)
         self.route('POST', ('folder',), self.createAnalysisFolder)

--- a/server/rest/dataset.py
+++ b/server/rest/dataset.py
@@ -41,6 +41,7 @@ import girder_client
 class Dataset(Resource):
 
     def __init__(self):
+        super(Dataset, self).__init__()
         self.resourceName = 'minerva_dataset'
         self.route('GET', (), self.listDatasets)
         self.route('GET', ('folder',), self.getDatasetFolder)

--- a/server/rest/feature.py
+++ b/server/rest/feature.py
@@ -11,6 +11,7 @@ import requests
 class FeatureInfo(Resource):
 
     def __init__(self):
+        super(FeatureInfo, self).__init__()
         self.resourceName = 'minerva_get_feature_info'
         self.route('GET', (), self.getFeatureInfo)
 

--- a/server/rest/geojson_dataset.py
+++ b/server/rest/geojson_dataset.py
@@ -28,6 +28,7 @@ from girder.plugins.minerva.utility.minerva_utility import findDatasetFolder, \
 
 class GeojsonDataset(Dataset):
     def __init__(self):
+        super(GeojsonDataset, self).__init__()
         self.resourceName = 'minerva_dataset_geojson'
         self.route('POST', (), self.createGeojsonDataset)
 

--- a/server/rest/postgres_geojson.py
+++ b/server/rest/postgres_geojson.py
@@ -12,6 +12,7 @@ from girder.plugins.minerva.utility.minerva_utility import findDatasetFolder
 class PostgresGeojson(Resource):
 
     def __init__(self):
+        super(PostgresGeojson, self).__init__()
         self.resourceName = 'minerva_postgres_geojson'
         self.route('GET', ('assetstores', ), self.getAssetstores)
         self.route('GET', ('tables', ), self.getTables)

--- a/server/rest/session.py
+++ b/server/rest/session.py
@@ -30,6 +30,7 @@ from girder.plugins.minerva.utility.minerva_utility import findSessionFolder
 
 class Session(Resource):
     def __init__(self):
+        super(Session, self).__init__()
         self.resourceName = 'minerva_session'
         self.route('GET', (), self.listSessions)
         self.route('GET', ('folder',), self.getSessionFolder)

--- a/server/rest/twofishes.py
+++ b/server/rest/twofishes.py
@@ -35,6 +35,7 @@ from girder.plugins.minerva.utility.minerva_utility import findDatasetFolder
 class TwoFishes(Resource):
     """Resource that handles geocoding related operations"""
     def __init__(self):
+        super(TwoFishes, self).__init__()
         self.resourceName = 'minerva_geocoder'
         self.route('GET', ('autocomplete',), self.autocomplete)
         self.route('GET', ('geojson',), self.getGeojson)

--- a/server/rest/wms_dataset.py
+++ b/server/rest/wms_dataset.py
@@ -35,6 +35,7 @@ import json
 class WmsDataset(Dataset):
 
     def __init__(self):
+        super(WmsDataset, self).__init__()
         self.resourceName = 'minerva_datasets_wms'
         self.route('POST', (), self.createWmsSource)
 

--- a/server/rest/wms_styles.py
+++ b/server/rest/wms_styles.py
@@ -265,6 +265,7 @@ class WmsStyle(object):
 class Sld(Resource):
 
     def __init__(self):
+        super(Sld, self).__init__()
         self.resourceName = 'minerva_style_wms'
         self.route('POST', (), self.sld_meta)
 

--- a/web_external/models/DatasetModel.js
+++ b/web_external/models/DatasetModel.js
@@ -46,7 +46,13 @@ const DatasetModel = MinervaModel.extend({
      */
     _preprocess: function () {
         if (this.getDatasetType().match(/(geo)?json/)) {
-            this.set('geoData', geojsonUtil.normalize(this.get('geoData')));
+            var geoData = geojsonUtil.normalize(this.get('geoData'));
+            var visProperties = this.getMinervaMetadata().visProperties;
+            if (visProperties.polygon.fillColorKey && geoData.summary[visProperties.polygon.fillColorKey]) {
+                visProperties.polygon.maxClamp = geoData.summary[visProperties.polygon.fillColorKey].max;
+                visProperties.polygon.minClamp = geoData.summary[visProperties.polygon.fillColorKey].min;
+            }
+            this.set('geoData', geoData);
         }
     },
 

--- a/web_external/stylesheets/body/layersPanel.styl
+++ b/web_external/stylesheets/body/layersPanel.styl
@@ -9,32 +9,22 @@
         margin 2px
         padding 2px
 
-    .icon-eye
-        float left
+    .icon-button
+        color #444
 
-    .icon-eye-off
-        float left
+        &:hover
+            color #66a
+            cursor pointer
 
     .m-push-right
         float right
-        .m-remove-dataset-from-layer
-            color #444
 
-            &:hover
-                color #66a
-                cursor pointer
+        > i
+            display block
+            float left
 
-        .m-download-geojson
-            color #444
-
-            &:hover
-                color #66a
-                cursor pointer
 
     .m-remove-dataset-from-layer.icon-attention
         color #ff751a
         float left
 
-        &:hover
-            color #d35400
-            cursor pointer

--- a/web_external/templates/body/dataPanel.pug
+++ b/web_external/templates/body/dataPanel.pug
@@ -45,22 +45,3 @@ if sourceCategoryDataset
                   if dataset.isGeoRenderable()
                     - var classes = (dataset.get('displayed') ? 'icon-globe icon-disabled dataset-in-session' : 'icon-globe icon-enabled add-dataset-to-session')
                     i(title='add to layers', class=classes)&attributes(attributes)
-
-                  //- Cog icon for geo rendering configuration
-                  if geoRenderType === 'geojson' || geoRenderType === 'geojson-timeseries'
-                    - var classes = 'icon-cog m-configure-geo-render'
-                    - classes += (dataset.get('displayed') ? ' icon-disabled dataset-in-session' : ' icon-enabled');
-                    - classes += ((!dataset.get('displayed') && dataset.get('geoError')) ? ' m-geo-render-error' : '');
-                    i(class=classes)&attributes(attributes)
-
-                  if geoRenderType === 'wms'
-                    - var classes = 'icon-cog m-configure-wms-styling'
-                    - classes += (dataset.get('displayed') ? ' icon-disabled dataset-in-session' : ' icon-enabled');
-                    - classes += ((!dataset.get('displayed') && dataset.get('geoError')) ? ' m-geo-render-error' : '');
-                    i(class=classes)&attributes(attributes)
-
-                  //- Table icon for csv
-                  if dataset.getDatasetType() === 'csv'
-                    - var classes = 'icon-table m-display-dataset-table'
-                    - classes += (dataset.get('displayed') ? ' icon-disabled dataset-in-session' : ' icon-enabled');
-                    i(class=classes)&attributes(attributes)

--- a/web_external/templates/body/layersPanel.pug
+++ b/web_external/templates/body/layersPanel.pug
@@ -7,16 +7,40 @@ include ../widgets/legendWidget.pug
   .layersList
     ul.datasets
       each dataset, index in datasets
-        li.dataset&attributes({'m-dataset-id': dataset.get('_id')})
+        - var attributes = {'m-dataset-id': dataset.get('_id')}
+        li.dataset&attributes(attributes)
           if dataset.get('geoError')
-            i.icon-attention.m-remove-dataset-from-layer&attributes({'m-dataset-id': dataset.get('_id')})
+            i.icon-attention.m-remove-dataset-from-layer&attributes(attributes)
           else
-            i.icon-eye.m-toggle-dataset&attributes({'m-dataset-id': dataset.get('_id')})
+            i.icon-eye.icon-button.m-toggle-dataset&attributes(attributes)
+            - var geoRenderType = dataset.getGeoRenderType()
+
             span= dataset.get('name')
             .m-push-right
+              //- Cog icon for geo rendering configuration
+              if geoRenderType === 'geojson' || geoRenderType === 'geojson-timeseries'
+                - var classes = 'icon-cog icon-button m-configure-geo-render'
+                - classes += (dataset.get('displayed') ? ' icon-disabled dataset-in-session' : ' icon-enabled');
+                - classes += ((!dataset.get('displayed') && dataset.get('geoError')) ? ' m-geo-render-error' : '');
+                i(class=classes)&attributes(attributes)
+
+              //- if geoRenderType === 'wms'
+              //-   - var classes = 'icon-cog m-configure-wms-styling'
+              //-   - classes += (dataset.get('displayed') ? ' icon-disabled dataset-in-session' : ' icon-enabled');
+              //-   - classes += ((!dataset.get('displayed') && dataset.get('geoError')) ? ' m-geo-render-error' : '');
+              //-   i(class=classes)&attributes(attributes)
+
+              //- //- Table icon for csv
+              //- if dataset.getDatasetType() === 'csv'
+              //-   - var classes = 'icon-table m-display-dataset-table'
+              //-   - classes += (dataset.get('displayed') ? ' icon-disabled dataset-in-session' : ' icon-enabled');
+              //-   i(class=classes)&attributes(attributes)
+              
               if dataset.getDatasetType() === 'geojson' || dataset.getDatasetType() === 'geojson-timeseries'
-                i.icon-download.m-download-geojson&attributes({'m-dataset-id': dataset.get('_id')})
-              i.icon-trash.m-remove-dataset-from-layer&attributes({'m-dataset-id': dataset.get('_id')})
+                i.icon-download.icon-button.m-download-geojson&attributes(attributes)
+              i.icon-trash.icon-button.m-remove-dataset-from-layer&attributes(attributes)
+
+            
           .m-layer-control-container
             each option in layersOrderOptions
               if ((index === 0 && option.class.indexOf('up') > -1) || (index === datasets.length - 1 && option.class.indexOf('down') > -1 ))
@@ -26,7 +50,7 @@ include ../widgets/legendWidget.pug
               i(title=option.title, class=`icon-angle-${option.class} m-order-layer ${disable}`)&attributes({'m-dataset-id': dataset.get('_id'), 'm-order-option': option.method})
             .m-layer-control-container
               i.icon-ajust
-              input.m-opacity-range&attributes({'m-dataset-id': dataset.get('_id')})(type='range', min=0, max=1, step=0.01, value=dataset.get('opacity'))
+              input.m-opacity-range&attributes(attributes)(type='range', min=0, max=1, step=0.01, value=dataset.get('opacity'))
               - var renderType = dataset.getGeoRenderType()
               if (renderType === 'wms')
                 - var legend = 'data:image/png;base64,' + dataset.metadata().legend

--- a/web_external/templates/body/layersPanel.pug
+++ b/web_external/templates/body/layersPanel.pug
@@ -40,7 +40,6 @@ include ../widgets/legendWidget.pug
                 i.icon-download.icon-button.m-download-geojson&attributes(attributes)
               i.icon-trash.icon-button.m-remove-dataset-from-layer&attributes(attributes)
 
-            
           .m-layer-control-container
             each option in layersOrderOptions
               if ((index === 0 && option.class.indexOf('up') > -1) || (index === datasets.length - 1 && option.class.indexOf('down') > -1 ))

--- a/web_external/templates/body/layersPanel.pug
+++ b/web_external/templates/body/layersPanel.pug
@@ -24,6 +24,7 @@ include ../widgets/legendWidget.pug
                 - classes += ((!dataset.get('displayed') && dataset.get('geoError')) ? ' m-geo-render-error' : '');
                 i(class=classes)&attributes(attributes)
 
+              // uncomment this line to enable wms layer
               //- if geoRenderType === 'wms'
               //-   - var classes = 'icon-cog m-configure-wms-styling'
               //-   - classes += (dataset.get('displayed') ? ' icon-disabled dataset-in-session' : ' icon-enabled');

--- a/web_external/templates/widgets/geoJSONStyleWidget.pug
+++ b/web_external/templates/widgets/geoJSONStyleWidget.pug
@@ -137,7 +137,7 @@ ul.nav.nav-tabs
     - var clampingEnabled = polygon.clampingFlag && polygon.linearFlag
     #m-clamping-panel.panel(class={'panel-default': !clampingEnabled, 'panel-primary': clampingEnabled})
       .panel-heading(data-target='#m-polygon-clamping-control')
-        .checkbox(style='display:block')
+        .checkbox(style='display:inline')
           label
             input#m-enable-linear-scale-clamping.m-toggle-panel(type='checkbox', checked=polygon.clampingFlag, data-feature='polygon', data-property='clampingFlag')
             | Clamping

--- a/web_external/templates/widgets/jsonConfigWidget.pug
+++ b/web_external/templates/widgets/jsonConfigWidget.pug
@@ -6,10 +6,12 @@
         h4.modal-title
           | Visual mapping
       .modal-body
-        .m-geojson-style.hidden
+        .m-geojson-style.hidden(assume-no-change)
 
       .modal-footer
+        .checkbox
+          label
+            input.save-to-dataset(type="checkbox", checked=saveToDataset)
+            | Save to dataset
         a.btn.btn-small.btn-default(data-dismiss="modal") Cancel
-        button.m-geo-render-button.btn.btn-small.btn-primary(type="submit")
-          i.icon-check
-          | Save
+        button.m-geo-render-button.btn.btn-small.btn-primary(type="submit") OK

--- a/web_external/views/body/DataPanel.js
+++ b/web_external/views/body/DataPanel.js
@@ -8,8 +8,6 @@ import Panel from '../body/Panel';
 import AddWmsSourceWidget from '../widgets/AddWmsSourceWidget';
 import StyleWmsDatasetWidget from '../widgets/StyleWmsDatasetWidget';
 import CsvViewerWidget from '../widgets/CsvViewerWidget';
-import ChoroplethRenderWidget from '../widgets/ChoroplethRenderWidget';
-import JsonConfigWidget from '../widgets/JsonConfigWidget';
 import DatasetModel from '../../models/DatasetModel';
 import DatasetInfoWidget from '../widgets/DatasetInfoWidget';
 import PostgresWidget from '../widgets/PostgresWidget';

--- a/web_external/views/body/DataPanel.js
+++ b/web_external/views/body/DataPanel.js
@@ -26,7 +26,6 @@ export default Panel.extend({
         'click .delete-dataset': 'deleteDatasetEvent',
         'click .m-display-dataset-table': 'displayTableDataset',
         'click .dataset-info': 'displayDatasetInfo',
-        'click .m-configure-geo-render': 'configureGeoRender',
         'click .m-configure-wms-styling': 'styleWmsDataset',
         'click .source-title': 'toggleSources',
         'click .category-title': 'toggleCategories'
@@ -118,40 +117,6 @@ export default Panel.extend({
                 data: dataset.get('tableData')
             }).render();
         }, this).loadTabularData();
-    },
-
-    /**
-     * Display a modal dialog allowing configuration of GeoJs rendering
-     * properties for the selected dataset.
-     */
-    configureGeoRender: function (event) {
-        var datasetId = $(event.currentTarget).attr('m-dataset-id');
-        var dataset = this.collection.get(datasetId);
-        var geoRenderType = dataset.getGeoRenderType();
-        if (dataset.get('displayed') || geoRenderType === null) {
-            // Don't pop up the modal when the dataset is active,
-            // or it can't be configured.
-            return;
-        }
-        var configureWidgets = {
-            'choropleth': ChoroplethRenderWidget,
-            'geojson': JsonConfigWidget,
-            'geojson-timeseries': JsonConfigWidget,
-            'contour': JsonConfigWidget
-        };
-        if (!this.configureWidgets) {
-            this.configureWidgets = {};
-        }
-        if (!this.configureWidgets[geoRenderType]) {
-            this.configureWidgets[geoRenderType] = new (configureWidgets[geoRenderType])({
-                el: $('#g-dialog-container'),
-                dataset: dataset,
-                parentView: this
-            });
-            this.configureWidgets[geoRenderType].render();
-        } else {
-            this.configureWidgets[geoRenderType].setCurrentDataset(dataset);
-        }
     },
 
     /**

--- a/web_external/views/body/LayersPanel.js
+++ b/web_external/views/body/LayersPanel.js
@@ -1,6 +1,9 @@
 import _ from 'underscore';
 
 import Panel from '../body/Panel';
+import ChoroplethRenderWidget from '../widgets/ChoroplethRenderWidget';
+import JsonConfigWidget from '../widgets/JsonConfigWidget';
+
 import template from '../../templates/body/layersPanel.pug';
 import '../../stylesheets/body/layersPanel.styl';
 import '../../stylesheets/widgets/animationControls.styl';
@@ -11,6 +14,7 @@ const LayersPanel = Panel.extend({
         'click .m-download-geojson': 'downloadGeojsonEvent',
         'click .m-remove-dataset-from-layer': 'removeDatasetEvent',
         'click .m-toggle-dataset': 'toggleDatasetEvent',
+        'click .m-configure-geo-render': 'configureGeoRender',
         'change .m-opacity-range': 'changeLayerOpacity',
         'click .m-order-layer': 'reorderLayer',
         'click .m-anim-play': 'seriesFramePlay',
@@ -54,6 +58,32 @@ const LayersPanel = Panel.extend({
         var dataset = this.collection.get(datasetId);
 
         dataset.set('visible', !dataset.get('visible'));
+    },
+
+    /**
+     * Display a modal dialog allowing configuration of GeoJs rendering
+     * properties for the selected dataset.
+     */
+    configureGeoRender: function (event) {
+        var datasetId = $(event.currentTarget).attr('m-dataset-id');
+        var dataset = this.collection.get(datasetId);
+        var geoRenderType = dataset.getGeoRenderType();
+
+        console.log(dataset);
+
+        var configureWidget = {
+            'choropleth': ChoroplethRenderWidget,
+            'geojson': JsonConfigWidget,
+            'geojson-timeseries': JsonConfigWidget,
+            'contour': JsonConfigWidget
+        }[geoRenderType];
+
+        new configureWidget({
+            el: $('#g-dialog-container'),
+            dataset: dataset,
+            parentView: this
+        })
+        .render();
     },
 
     changeLayerOpacity: function (event) {

--- a/web_external/views/body/LayersPanel.js
+++ b/web_external/views/body/LayersPanel.js
@@ -71,14 +71,14 @@ const LayersPanel = Panel.extend({
 
         console.log(dataset);
 
-        var configureWidget = {
+        var ConfigureWidget = {
             'choropleth': ChoroplethRenderWidget,
             'geojson': JsonConfigWidget,
             'geojson-timeseries': JsonConfigWidget,
             'contour': JsonConfigWidget
         }[geoRenderType];
 
-        new configureWidget({
+        new ConfigureWidget({
             el: $('#g-dialog-container'),
             dataset: dataset,
             parentView: this

--- a/web_external/views/body/LayersPanel.js
+++ b/web_external/views/body/LayersPanel.js
@@ -69,8 +69,6 @@ const LayersPanel = Panel.extend({
         var dataset = this.collection.get(datasetId);
         var geoRenderType = dataset.getGeoRenderType();
 
-        console.log(dataset);
-
         var ConfigureWidget = {
             'choropleth': ChoroplethRenderWidget,
             'geojson': JsonConfigWidget,

--- a/web_external/views/map/MapPanel.js
+++ b/web_external/views/map/MapPanel.js
@@ -170,7 +170,7 @@ const MapPanel = Panel.extend({
 
             this._renderDataset(dataset, layerType, visProperties);
 
-            dataset.on('m:dataset_config_change', () => {
+            this.listenTo(dataset, 'm:dataset_config_change', () => {
                 this.removeDataset(dataset);
                 let visProperties = (dataset.getMinervaMetadata() || {}).visProperties || {};
                 this._renderDataset(dataset, layerType, visProperties);
@@ -197,6 +197,7 @@ const MapPanel = Panel.extend({
      * Remove a rendered dataset from the current map.
      */
     removeDataset: function (dataset) {
+        this.stopListening(dataset);
         var datasetId = dataset.get('_id');
         var layerRepr = this.datasetLayerReprs[datasetId];
         if (layerRepr) {

--- a/web_external/views/map/MapPanel.js
+++ b/web_external/views/map/MapPanel.js
@@ -156,9 +156,8 @@ const MapPanel = Panel.extend({
         if (!dataset.metadata()) {
             return;
         }
-        var datasetId = dataset.get('_id');
 
-        if (!_.contains(this.datasetLayerReprs, datasetId)) {
+        if (!_.contains(this.datasetLayerReprs, dataset.get('_id'))) {
             // For now, get the layerType directly from the dataset,
             // but we should really allow the user to specify the desired
             // layerType.
@@ -169,19 +168,32 @@ const MapPanel = Panel.extend({
                 visProperties = (dataset.getMinervaMetadata() || {}).visProperties || {};
             }
 
-            dataset.once('m:map_adapter_layerCreated', function (repr) {
-                this.datasetLayerReprs[datasetId] = repr;
-                repr.render(this);
-            }, this).once('m:map_adapter_error', function (dataset, layerType) {
-                dataset.set('geoError', true);
-            }, this).once('m:map_adapter_layerError', function (repr) {
-                if (repr) {
-                    repr.delete(this);
-                    dataset.set('geoError', true);
-                }
-            }, this);
-            adapterRegistry._createRepresentation(this, dataset, layerType, visProperties);
+            this._renderDataset(dataset, layerType, visProperties);
+
+
+            dataset.on('m:dataset_config_change', () => {
+                this.removeDataset(dataset);
+                let visProperties = (dataset.getMinervaMetadata() || {}).visProperties || {};
+                this._renderDataset(dataset, layerType, visProperties);
+            });
         }
+    },
+
+    _renderDataset(dataset, layerType, visProperties) {
+        dataset.once('m:map_adapter_layerCreated', function (repr) {
+            console.log("m:map_adapter_layerCreated");
+            this.datasetLayerReprs[dataset.get('_id')] = repr;
+            repr.render(this);
+        }, this).once('m:map_adapter_error', function (dataset, layerType) {
+            dataset.set('geoError', true);
+        }, this).once('m:map_adapter_layerError', function (repr) {
+            if (repr) {
+                repr.delete(this);
+                dataset.set('geoError', true);
+            }
+        }, this);
+        console.log("visProperties", visProperties);
+        adapterRegistry._createRepresentation(this, dataset, layerType, visProperties);
     },
 
     /**

--- a/web_external/views/map/MapPanel.js
+++ b/web_external/views/map/MapPanel.js
@@ -170,7 +170,6 @@ const MapPanel = Panel.extend({
 
             this._renderDataset(dataset, layerType, visProperties);
 
-
             dataset.on('m:dataset_config_change', () => {
                 this.removeDataset(dataset);
                 let visProperties = (dataset.getMinervaMetadata() || {}).visProperties || {};
@@ -181,7 +180,6 @@ const MapPanel = Panel.extend({
 
     _renderDataset(dataset, layerType, visProperties) {
         dataset.once('m:map_adapter_layerCreated', function (repr) {
-            console.log("m:map_adapter_layerCreated");
             this.datasetLayerReprs[dataset.get('_id')] = repr;
             repr.render(this);
         }, this).once('m:map_adapter_error', function (dataset, layerType) {
@@ -192,7 +190,6 @@ const MapPanel = Panel.extend({
                 dataset.set('geoError', true);
             }
         }, this);
-        console.log("visProperties", visProperties);
         adapterRegistry._createRepresentation(this, dataset, layerType, visProperties);
     },
 

--- a/web_external/views/view.js
+++ b/web_external/views/view.js
@@ -1,4 +1,12 @@
+import $ from 'jquery';
+import reconcile from 'reconcile.js';
 import View from 'girder/views/View';
 
-const MinervaView = View.extend({});
+const MinervaView = View.extend({
+    update(template) {
+        var $new = $(template);
+        var changes = reconcile.diff($new[0], this.$el.children(0)[0]);
+        reconcile.apply(changes, this.$el.children(0)[0]);
+    }
+});
 export default MinervaView;

--- a/web_external/views/widgets/GeoJSONStyleWidget.js
+++ b/web_external/views/widgets/GeoJSONStyleWidget.js
@@ -9,6 +9,8 @@ import GeoJSONStyle from '../../models/GeoJSONStyle';
 import geojsonUtil from '../../geojsonUtil';
 import template from '../../templates/widgets/geoJSONStyleWidget.pug';
 
+import '../../stylesheets/widgets/geoJSONStyleWidget.styl';
+
 function _updateClampingPanel(radio) {
     var radioChecked = radio.is(':checked');
     var panel = $('#m-clamping-panel');
@@ -103,7 +105,7 @@ const GeoJSONStyleWidget = View.extend({
     /**
      * Save the user selected values into the geojson object.
      */
-    save: function () {
+    updateDataset(save = false) {
         var props = {
             point: this._pointStyle.attributes,
             line: this._lineStyle.attributes,
@@ -111,7 +113,9 @@ const GeoJSONStyleWidget = View.extend({
         };
         var mm = this._dataset.getMinervaMetadata();
         mm.visProperties = props;
-        this._dataset.saveMinervaMetadata(mm);
+        if (save) {
+            this._dataset.saveMinervaMetadata(mm);
+        }
     },
 
     _fixTooltips: function () {

--- a/web_external/views/widgets/JsonConfigWidget.js
+++ b/web_external/views/widgets/JsonConfigWidget.js
@@ -2,7 +2,6 @@ import View from '../view';
 import GeoJSONStyleWidget from './GeoJSONStyleWidget';
 import template from '../../templates/widgets/jsonConfigWidget.pug';
 import '../../stylesheets/widgets/jsonConfigWidget.styl';
-import '../../stylesheets/widgets/geoJSONStyleWidget.styl';
 /**
  * This widget displays options for rendering json datasets.
  */
@@ -11,26 +10,32 @@ const JsonConfigWidget = View.extend({
         'submit #m-json-geo-render-form': function (e) {
             e.preventDefault();
             this.$('.g-validation-failed-message').text('');
-            this.jsonStyleWidget.save();
-            this.dataset._initGeoRender('geojson');
+            this.jsonStyleWidget.updateDataset(this.saveToDataset);
+            this.dataset.trigger('m:dataset_config_change', this);
             this.$el.modal('hide');
+        },
+        'change .save-to-dataset': function (e) {
+            this.saveToDataset = e.currentTarget.checked;
+            this.render();
         }
     },
 
     initialize: function (settings) {
         this.dataset = settings.dataset;
+        this.saveToDataset = false;
+        this.modalOpened = false;
     },
 
     render: function () {
-        var modal = this.$el.html(template()).girderModal(this);
-        this._loadDataset();
-        modal.trigger($.Event('reader.girder.modal', {relatedTarget: modal}));
+        if (this.modalOpened) {
+            this.update(template(this));
+        } else {
+            this.modalOpened = true;
+            var modal = this.$el.html(template(this)).girderModal(this);
+            this._loadDataset();
+            modal.trigger($.Event('reader.girder.modal', { relatedTarget: modal }));
+        }
         return this;
-    },
-
-    setCurrentDataset: function (dataset) {
-        this.dataset = dataset;
-        this.render();
     },
 
     _loadDataset: function () {


### PR DESCRIPTION
This PR moves the styling option onto layer panel.
Since BSVE doesn't have a good session concept, the style is still saved to the dataset, when needed (with a checkbox).

Also, I talked about a library called reconcile.js, which mimics the way React update the dom. Over the past development with Minerva, I constantly find myself need the DOM merging updating. 
I included it in this PR as a utility function (Probably will always be), it worked great for this PR. I think it will help this and future developments. 
However, it's currently using a forked version of mine, which adds an option to help parent child view relationship.

![2017-09-07_08-49-01](https://user-images.githubusercontent.com/3123478/30330212-6703870e-97a2-11e7-88e9-871d79bf4d1f.gif)
