### PR TITLE
Relax requirement pinning.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
-cffi==1.5.0
-cryptography==1.3.2
+cffi>=1.5.0
+cryptography>=1.3.2
 geojson==1.3.2
 geopy==1.10.0
 girder-client==2.2.1
 ijson==2.2.0
 jsonpath-rw==1.4.0
 matplotlib==1.5.3
-numpy==1.10.1
+numpy>=1.10.1
 owslib==0.9.1
 python-dateutil==2.4.2
 Shapely==1.6.0


### PR DESCRIPTION
A recent release of paramiko requires cryptography 1.5.  Either girder has to pin the paramiko version or the minerva plugin has to unpin cryptography.  Unpinning is better.