### PR TITLE
Try picking a property for initial styling

### DIFF
--- a/web_external/models/DatasetModel.js
+++ b/web_external/models/DatasetModel.js
@@ -65,7 +65,7 @@ const DatasetModel = MinervaModel.extend({
 
     tryGetDefaultFillColor(summary) {
         var numberFields = _.pairs(summary).filter((pair) => {
-            return !pair[1].values;
+            return !pair[1].values && isFinite(pair[1].min) && isFinite(pair[1].max) && pair[1].min !== pair[1].max;
         });
         if (numberFields.length) {
             return {
@@ -74,7 +74,7 @@ const DatasetModel = MinervaModel.extend({
             };
         }
         var categoricalFields = _.pairs(summary).filter((pair) => {
-            return pair[1].values;
+            return pair[1].values && pair[1].values.length >= 2;
         });
         if (categoricalFields.length) {
             return {
@@ -82,6 +82,7 @@ const DatasetModel = MinervaModel.extend({
                 fillRamp: 'Pastel1'
             };
         }
+        return null;
     },
 
     _applyDefaultStyle: function () {


### PR DESCRIPTION
This PR adds a feature to automatically tries to select a property to set default style. https://github.com/Kitware/minerva/issues/438
The priority of the selection is 
wider range sequential > smaller range sequential > more category qualitative > less category quantitative

Before:
![2017-10-02_13-56-50](https://user-images.githubusercontent.com/3123478/31092648-1759c976-a77d-11e7-9836-74c12089b22f.gif)

Ater:
![2017-10-02_13-56-15](https://user-images.githubusercontent.com/3123478/31092650-19ef2bea-a77d-11e7-8d19-032153dca0d3.gif)
![2017-10-02_14-22-11](https://user-images.githubusercontent.com/3123478/31092651-1af49aa2-a77d-11e7-976d-4044d33e6a15.gif)


