### PR TITLE
Fix the alert pop up style

### DIFF
--- a/web_external/MinervaModel.js
+++ b/web_external/MinervaModel.js
@@ -86,7 +86,7 @@ const MinervaModel = ItemModel.extend({
             events.trigger('g:alert', {
                 icon: 'cancel',
                 text: 'Could not update Minerva metadata in Item.',
-                type: 'error',
+                type: 'danger',
                 timeout: 4000
             });
         }, this));

--- a/web_external/models/DatasetModel.js
+++ b/web_external/models/DatasetModel.js
@@ -130,7 +130,7 @@ const DatasetModel = MinervaModel.extend({
             events.trigger('g:alert', {
                 icon: 'cancel',
                 text: 'Could not create dataset from dataset item.',
-                type: 'error',
+                type: 'danger',
                 timeout: 4000
             });
         }, this));
@@ -255,7 +255,7 @@ const DatasetModel = MinervaModel.extend({
                 events.trigger('g:alert', {
                     icon: 'cancel',
                     text: 'Could not download geoData in Dataset.',
-                    type: 'error',
+                    type: 'danger',
                     timeout: 4000
                 });
             }, this));
@@ -311,7 +311,7 @@ const DatasetModel = MinervaModel.extend({
                 events.trigger('g:alert', {
                     icon: 'cancel',
                     text: 'Could not download the tabular data file.',
-                    type: 'error',
+                    type: 'danger',
                     timeout: 4000
                 });
             }, this));

--- a/web_external/views/body/AnalysisPanel.js
+++ b/web_external/views/body/AnalysisPanel.js
@@ -29,7 +29,7 @@ const AnalysisPanel = Panel.extend({
             events.trigger('g:alert', {
                 icon: 'cancel',
                 text: message,
-                type: 'error',
+                type: 'danger',
                 timeout: 4000
             });
 


### PR DESCRIPTION
The background of the alert popup was transparent, it is because the wrong type is used.
This will make it light red translucent, same as it is in girder.