### PR TITLE
Remove moment from package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "jade": "~1.11.0",
     "jquery-extendext": "^0.1.2",
     "jquery-ui-bundle": "^1.11.4",
-    "moment": "^2.17.1",
     "reconcile.js": "^1.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Girder added moment as a explicit dependency, so remove it from Minerva.  As an odd side effect of having it in both places, occasionally the girder web build leaves remnants of it in girder/client/web/src/node_modules.