### PR TITLE
Unpin development requirements.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,2 @@
-geopandas==0.1.1
-netCDF4==1.1.8
-Sphinx==1.3.5
-sphinx_rtd_theme==0.1.9
+Sphinx>=1.3.5
+sphinx_rtd_theme>=0.1.9


### PR DESCRIPTION
Remove unused development requirements.

Unpinning Sphinx avoids conflicts with Girder core.