### PR TITLE
Draw boundary dataset and boundary filtering

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,8 @@ module.exports = {
         'no-alert': 0,
         'underscore/prefer-invoke': 0,
         'promise/no-native': 0,
+        'promise/no-nesting': 'off',
+        'promise/always-return': 'off'
     },
     globals: {
         minerva: true,

--- a/plugin_tests/client/minervaSpec.js
+++ b/plugin_tests/client/minervaSpec.js
@@ -254,23 +254,23 @@ describe('Datapanel', function () {
         }, 'boundaries to be drawn');
 
         runs(function () {
-            expect(mapPanel.annotationLayer).not.toBeFalsy();
-            expect(mapPanel.annotationLayer.annotations().length).toEqual(4);
+            expect(mapPanel.boundariesAnnotationLayer).not.toBeFalsy();
+            expect(mapPanel.boundariesAnnotationLayer.annotations().length).toEqual(4);
         });
     });
 
     it('Toggle boundary label', function () {
         var mapPanel = $('#m-map-panel').data('backboneView')[0];
         $('.icon-button.toggle-bounds-label').trigger('click');
-        expect(mapPanel.annotationLayer.options().showLabels).toEqual(true);
+        expect(mapPanel.boundariesAnnotationLayer.options().showLabels).toEqual(true);
         $('.icon-button.toggle-bounds-label').trigger('click');
-        expect(mapPanel.annotationLayer.options().showLabels).toEqual(false);
+        expect(mapPanel.boundariesAnnotationLayer.options().showLabels).toEqual(false);
     });
 
     it('Hide dataset boundaries', function () {
         var mapPanel = $('#m-map-panel').data('backboneView')[0];
         $('.icon-button.remove-bounds').trigger('click');
-        expect(mapPanel.annotationLayer).toBeFalsy();
+        expect(mapPanel.boundariesAnnotationLayer).toBeFalsy();
     });
 });
 

--- a/plugin_tests/client/minervaSpec.js
+++ b/plugin_tests/client/minervaSpec.js
@@ -219,6 +219,7 @@ describe('Session view', function () {
 });
 
 describe('Datapanel', function () {
+    var mapPanel;
     it('Select and unselect datasets', function () {
         $('.source-title#Tiff').trigger('click');
         $('.source-title#GeoJSON').trigger('click');
@@ -241,7 +242,7 @@ describe('Datapanel', function () {
     });
 
     it('Show dataset boundaries', function () {
-        var mapPanel = $('#m-map-panel').data('backboneView')[0];
+        mapPanel = $('#m-map-panel').data('backboneView')[0];
         runs(function () {
             $('.source-title#Tiff').next('.m-sub-category').find('.category-title#Other input').trigger('change');
             $('.source-title#GeoJSON').next('.m-sub-category').find('.category-title#Other input').trigger('change');
@@ -260,7 +261,6 @@ describe('Datapanel', function () {
     });
 
     it('Toggle boundary label', function () {
-        var mapPanel = $('#m-map-panel').data('backboneView')[0];
         $('.icon-button.toggle-bounds-label').trigger('click');
         expect(mapPanel.boundariesAnnotationLayer.options().showLabels).toEqual(true);
         $('.icon-button.toggle-bounds-label').trigger('click');
@@ -268,9 +268,37 @@ describe('Datapanel', function () {
     });
 
     it('Hide dataset boundaries', function () {
-        var mapPanel = $('#m-map-panel').data('backboneView')[0];
         $('.icon-button.remove-bounds').trigger('click');
         expect(mapPanel.boundariesAnnotationLayer).toBeFalsy();
+    });
+
+    it('Create boundary dataset with drawing', function () {
+        $('.icon-button.m-boundary-dataset').trigger('click');
+        mapPanel.drawDatasetLayer.geojson({ 'type': 'FeatureCollection', 'features': [{ 'type': 'Feature', 'geometry': { 'type': 'Polygon', 'coordinates': [[[-123.774414, 32.887971], [-123.774414, 39.748663], [-104.721679, 39.748663], [-104.721679, 32.887971], [-123.774414, 32.887971]]] }, 'properties': { 'annotationType': 'rectangle', 'name': 'Rectangle 1', 'annotationId': 1, 'fill': true, 'fillColor': '#00ff00', 'fillOpacity': 0.25, 'stroke': true, 'strokeColor': '#000000', 'strokeOpacity': 1, 'strokeWidth': 3 } }] });
+        mapPanel.drawDatasetLayer.geoTrigger(geo.event.annotation.state, {});
+        waitsFor(function () {
+            return $('.bootbox-prompt .modal-footer .btn-primary').length;
+        }, 'confirm modal to show');
+        runs(function () {
+            $('.bootbox-prompt .modal-footer .btn-primary').trigger('click');
+        });
+        waitsFor(function () {
+            return $('.m-datasets[data-category=Boundary] .dataset .m-name:contains(Boundary.geojson)').length &&
+                !$('.modal-backdrop').length;
+        }, 'Boundary dataset to be created');
+    });
+
+    it('Filter datasets by intersecting', function () {
+        $('.m-datasets[data-category=Boundary] .dataset .m-name:contains(Boundary.geojson)').first().parent().find('input').trigger('click');
+        $('.icon-button.intersect-filter').trigger('click');
+        waitsFor(function () {
+            return $('.icon-button.remove-filter').length;
+        }, 'dataset to be filtered');
+        runs(function () {
+            expect($('.m-datasets .dataset').length).toBe(4);
+            $('.icon-button.remove-filter').trigger('click');
+            expect($('.m-datasets .dataset').length).not.toBe(3);
+        });
     });
 });
 

--- a/web_external/models/DatasetModel.js
+++ b/web_external/models/DatasetModel.js
@@ -119,7 +119,7 @@ const DatasetModel = MinervaModel.extend({
         return restRequest({
             url: 'minerva_dataset/' + this.get('_id') + '/item',
             type: 'POST'
-        }).done(_.bind(function (resp) {
+        }).then((resp) => {
             if (params && params.csvPreview) {
                 resp.meta.minerva.csv_preview = params.csvPreview;
             }
@@ -127,7 +127,8 @@ const DatasetModel = MinervaModel.extend({
             this._initGeoRender();
             this._applyDefaultStyle();
             this.trigger('m:dataset_promoted', this);
-        }, this)).fail(_.bind(function (err) {
+            return this;
+        }).fail((err) => {
             console.error(err);
             events.trigger('g:alert', {
                 icon: 'cancel',
@@ -135,7 +136,7 @@ const DatasetModel = MinervaModel.extend({
                 type: 'danger',
                 timeout: 4000
             });
-        }, this));
+        });
     },
 
     getDatasetType: function () {

--- a/web_external/templates/body/dataPanel.pug
+++ b/web_external/templates/body/dataPanel.pug
@@ -33,7 +33,7 @@ if sourceCategoryDataset
             i.icon-search
           button.icon-button.share(title='Share/Unshare selected datasets', disabled=!sharableSelectedDatasets().length)
             i.icon-share
-          if selectionCount === 1
+          if selectionCount === 1 && selectionGetBoundSupported()
             button.icon-button.intersect-filter(title='Show datasets that have boundaries overlap with selected dataset boundary')
               i.icon-filter
           if selectionCount > 1

--- a/web_external/templates/body/dataPanel.pug
+++ b/web_external/templates/body/dataPanel.pug
@@ -11,6 +11,9 @@ if sourceCategoryDataset
           i.m-icon-enabled.icon-upload
         button.icon-button.m-postgres(title="Create postgres dataset")
           i.m-icon-enabled.icon-database
+        button.icon-button.m-boundary-dataset(title="Draw a boundary dataset")
+          i.m-icon-enabled.icon-pencil
+        ||
         button.icon-button.toggle-shared(title=showSharedDatasets?'Hide shared datasets':'Show shared datasets')
           i.icon-user(class=showSharedDatasets?'':'icon-disabled')
         if showingBounds

--- a/web_external/templates/body/dataPanel.pug
+++ b/web_external/templates/body/dataPanel.pug
@@ -4,7 +4,7 @@ include ../layout/panelMixins.pug
 
 if sourceCategoryDataset
   +panel-content('collapse in')
-    - var hasSelection = selectedDatasetsId.size;
+    - var selectionCount = selectedDatasetsId.size;
     .action-bar
       .pull-left
         button.icon-button.m-upload-local(title="Upload local dataset")
@@ -22,17 +22,25 @@ if sourceCategoryDataset
             i.icon-font
           button.icon-button.remove-bounds(title='Remove dataset boundaries')
             i.icon-trash
+        if !_.isEmpty(filters)
+          ||
+          button.icon-button.remove-filter(title='Stop filtering')
+            i.icon-cancel
       | &nbsp;
-      if hasSelection
+      if selectionCount
         .pull-right
-          button.icon-button.show-bounds(title='Show boundaries of selected datasets', disabled=!hasSelection)
+          button.icon-button.show-bounds(title='Show boundaries of selected datasets')
             i.icon-search
           button.icon-button.share(title='Share/Unshare selected datasets', disabled=!sharableSelectedDatasets().length)
             i.icon-share
-          button.icon-button.add-to-session(title='Add selected datasets to session', disabled=!hasSelection)
-            i.icon-globe
-          button.icon-button.delete(title='Delete selected datasets', disabled=!deletableSelectedDatasets().length)
-            i.icon-trash
+          if selectionCount === 1
+            button.icon-button.intersect-filter(title='Show datasets that have boundaries overlap with selected dataset boundary')
+              i.icon-filter
+          if selectionCount > 1
+            button.icon-button.add-to-session(title='Add selected datasets to session')
+              i.icon-globe
+            button.icon-button.delete(title='Delete selected datasets', disabled=!deletableSelectedDatasets().length)
+              i.icon-trash
     each categories, source in sourceCategoryDataset
       .source-title.clearfix(id=source)= source
         - var expand = visibleMenus[source]
@@ -41,7 +49,7 @@ if sourceCategoryDataset
         each datasets, category in categories
           .category-title.clearfix(id=category, data-source=source, data-category=category)
             .pull-left
-              .category-checkbox.checkbox-container(class=hasSelection?'show-checkbox':'')
+              .category-checkbox.checkbox-container(class=selectionCount?'show-checkbox':'')
                 - expand = visibleMenus[source] && visibleMenus[source][category]
                 i.icon-faded(title='Collection', class=expand?'icon-folder-open':'icon-folder')
                 input(type='checkbox', checked=allChecked(datasets.map((dataset)=>dataset.get('_id'))))
@@ -52,7 +60,7 @@ if sourceCategoryDataset
                 - var attributes = {'m-dataset-id': dataset.get('_id')}
                 .dataset.clearfix&attributes(attributes)
                   .pull-left
-                    .dataset-checkbox.checkbox-container(class=hasSelection?'show-checkbox':'')
+                    .dataset-checkbox.checkbox-container(class=selectionCount?'show-checkbox':'')
                       if dataset.get('creatorId')===currentUser.id 
                         if dataset.get('folderId') === collection.folderId
                           i.icon-doc.icon-faded

--- a/web_external/templates/body/layersPanel.pug
+++ b/web_external/templates/body/layersPanel.pug
@@ -47,7 +47,8 @@ div
 
                 if dataset.getDatasetType() === 'geojson' || dataset.getDatasetType() === 'geojson-timeseries'
                   i.icon-download.icon-button.m-download-geojson&attributes(attributes)
-                i.icon-button.icon-search.m-zoom-to(title='Zoom to dataset')&attributes(attributes)
+                if getBoundSupported(dataset)
+                  i.icon-button.icon-search.m-zoom-to(title='Zoom to dataset')&attributes(attributes)
 
             .m-layer-control-container
               each option in layersOrderOptions

--- a/web_external/views/body/DataPanel.js
+++ b/web_external/views/body/DataPanel.js
@@ -6,6 +6,7 @@ import UploadWidget from 'girder/views/widgets/UploadWidget';
 import JobStatus from 'girder_plugins/jobs/JobStatus';
 import { getCurrentUser } from 'girder/auth';
 import { _whenAll } from 'girder/misc';
+import girderEvents from 'girder/events';
 
 import events from '../../events';
 import Panel from '../body/Panel';
@@ -13,6 +14,7 @@ import CsvViewerWidget from '../widgets/CsvViewerWidget';
 import DatasetModel from '../../models/DatasetModel';
 import DatasetInfoWidget from '../widgets/DatasetInfoWidget';
 import PostgresWidget from '../widgets/PostgresWidget';
+import { getBoundSupported } from '../util/utils';
 import template from '../../templates/body/dataPanel.pug';
 import '../../stylesheets/body/dataPanel.styl';
 
@@ -231,6 +233,11 @@ export default Panel.extend({
         });
     },
 
+    selectionGetBoundSupported() {
+        var dataset = this.collection.get(this.selectedDatasetsId.values().next().value);
+        return getBoundSupported(dataset);
+    },
+
     sharableSelectedDatasets() {
         return Array.from(this.selectedDatasetsId)
             .map((datasetId) => this.collection.get(datasetId))
@@ -283,6 +290,7 @@ export default Panel.extend({
         this._ = _;
         this.deletableSelectedDatasets = this.deletableSelectedDatasets.bind(this);
         this.sharableSelectedDatasets = this.sharableSelectedDatasets.bind(this);
+        this.selectionGetBoundSupported = this.selectionGetBoundSupported.bind(this);
         var externalId = 1;
         this.collection = settings.session.datasetCollection;
         this.sessionModel = settings.session.model;
@@ -445,12 +453,24 @@ export default Panel.extend({
         if (bounds) {
             return $.Deferred().resolve({ dataset, bounds });
         }
+        if (!getBoundSupported(dataset)) {
+            return $.Deferred().resolve({ dataset, bounds: null });
+        }
         return restRequest({
             type: 'GET',
             url: `minerva_dataset/${dataset.get('_id')}/bound`
         }).then((bounds) => {
             dataset.bounds = bounds;
             return { dataset, bounds };
+        }).catch((e) => {
+            if (e.status === 400) {
+                girderEvents.trigger('g:alert', {
+                    text: e.responseJSON.message,
+                    type: 'info',
+                    timeout: 5000,
+                    icon: 'info'
+                });
+            }
         });
     },
 
@@ -458,6 +478,17 @@ export default Panel.extend({
         _whenAll(
             this.collection.filter((dataset) => this.selectedDatasetsId.has(dataset.get('_id'))).map((dataset) => this._getDatasetBounds(dataset))
         ).then((results) => {
+            if (results.find((result) => {
+                return !result.bounds;
+            })) {
+                girderEvents.trigger('g:alert', {
+                    text: 'Show boundary is unsupported for some datasets',
+                    type: 'info',
+                    timeout: 5000,
+                    icon: 'info'
+                });
+            }
+            results = results.filter((result) => result.bounds);
             events.trigger('m:request-show-bounds', results);
             this.showingBounds = true;
             this.clearSelection();
@@ -479,7 +510,7 @@ export default Panel.extend({
     intersectFilter() {
         var dataset = this.collection.get(this.selectedDatasetsId.values().next().value);
         this._getDatasetBounds(dataset)
-            .then(({ datsaet, bounds }) => {
+            .then(({ dataset, bounds }) => {
                 var filterBounds = bounds;
                 _whenAll(
                     this.collection
@@ -493,6 +524,10 @@ export default Panel.extend({
                                 (bounds1.lry <= bounds2.uly && bounds1.lry >= bounds2.lry));
                     }
                     this.filters.intersect = results.filter(({ dataset, bounds }) => {
+                        // If can't find boundary, allow it to show
+                        if (!bounds) {
+                            return true;
+                        }
                         return check(bounds, filterBounds) || check(filterBounds, bounds);
                     }).map(({ dataset }) => dataset.get('_id'));
                     this.clearSelection();

--- a/web_external/views/body/DataPanel.js
+++ b/web_external/views/body/DataPanel.js
@@ -37,7 +37,9 @@ export default Panel.extend({
         'click .action-bar button.toggle-shared': 'toggleShared',
         'click .action-bar button.show-bounds': 'showBounds',
         'click .action-bar button.remove-bounds': 'removeBounds',
-        'click .action-bar button.toggle-bounds-label': 'toggleBoundsLabel'
+        'click .action-bar button.toggle-bounds-label': 'toggleBoundsLabel',
+        'click .action-bar button.intersect-filter': 'intersectFilter',
+        'click .action-bar button.remove-filter': 'removeFilter'
     },
 
     toggleCategories: function (event) {
@@ -154,6 +156,7 @@ export default Panel.extend({
         }
         this.newDataset.on('m:dataset_promoted', function () {
             this.collection.add(this.newDataset);
+            this.filters = {};
         }, this).on('g:error', function (err) {
             console.error(err);
         }).promoteToDataset(params);
@@ -277,6 +280,7 @@ export default Panel.extend({
     },
     initialize: function (settings) {
         this.allChecked = this.allChecked.bind(this);
+        this._ = _;
         this.deletableSelectedDatasets = this.deletableSelectedDatasets.bind(this);
         this.sharableSelectedDatasets = this.sharableSelectedDatasets.bind(this);
         var externalId = 1;
@@ -286,6 +290,7 @@ export default Panel.extend({
         this.visibleMenus = {};
         this.showSharedDatasets = !!this.sessionModel.getValue('showSharedDatasets');
         this.selectedDatasetsId = new Set();
+        this.filters = {};
         this.listenTo(this.collection, 'g:changed', function () {
             this.render();
         }, this).listenTo(this.collection, 'change', function () {
@@ -351,18 +356,18 @@ export default Panel.extend({
             this.collection.add(dataset);
         }, this);
 
-        this.listenTo(events, 'm:dataset-drawn', (geometry) => {
+        this.listenTo(events, 'm:dataset-drawn', (name, geometry) => {
             var geometryStr = JSON.stringify(geometry);
             return restRequest({
                 type: 'POST',
-                url: `file?parentType=folder&parentId=${this.collection.folderId}&name=boundary.geojson&size=${geometryStr.length}`,
-                contentType: "application/json",
+                url: `file?parentType=folder&parentId=${this.collection.folderId}&name=${name}.geojson&size=${geometryStr.length}`,
+                contentType: 'application/json',
                 data: geometryStr
             }).then((file) => {
                 return restRequest({
                     type: 'GET',
                     url: `item/${file.itemId}`
-                })
+                });
             }).then((item) => {
                 var dataset = new DatasetModel(item);
                 return dataset.promoteToDataset({});
@@ -471,13 +476,43 @@ export default Panel.extend({
         events.trigger('m:toggle-bounds-label');
     },
 
-    render() {
-        var sourceName = (model) => {
-            return (((model.get('meta') || {}).minerva || {}).source || {}).layer_source;
-        };
+    intersectFilter() {
+        var dataset = this.collection.get(this.selectedDatasetsId.values().next().value);
+        this._getDatasetBounds(dataset)
+            .then(({ datsaet, bounds }) => {
+                var filterBounds = bounds;
+                _whenAll(
+                    this.collection
+                        .filter(this.getSourceName)
+                        .map((dataset) => this._getDatasetBounds(dataset))
+                ).then((results) => {
+                    function check(bounds1, bounds2) {
+                        return ((bounds1.ulx <= bounds2.lrx && bounds1.ulx >= bounds2.ulx) ||
+                            (bounds1.lrx <= bounds2.lrx && bounds1.lrx >= bounds2.ulx)) &&
+                            ((bounds1.uly <= bounds2.uly && bounds1.uly >= bounds2.lry) ||
+                                (bounds1.lry <= bounds2.uly && bounds1.lry >= bounds2.lry));
+                    }
+                    this.filters.intersect = results.filter(({ dataset, bounds }) => {
+                        return check(bounds, filterBounds) || check(filterBounds, bounds);
+                    }).map(({ dataset }) => dataset.get('_id'));
+                    this.clearSelection();
+                    this.render();
+                });
+            });
+    },
 
+    removeFilter() {
+        this.filters = {};
+        this.render();
+    },
+
+    getSourceName(model) {
+        return (((model.get('meta') || {}).minerva || {}).source || {}).layer_source;
+    },
+
+    render() {
         this.sourceCategoryDataset = _.chain(this.collection.models)
-            .filter(sourceName)
+            .filter(this.getSourceName)
             .filter((dataset) => {
                 if (this.showSharedDatasets) {
                     return true;
@@ -485,7 +520,15 @@ export default Panel.extend({
                     return dataset.get('creatorId') === this.currentUser.id;
                 }
             })
-            .groupBy(sourceName)
+            .filter((dataset) => {
+                if (_.isEmpty(this.filters)) {
+                    return true;
+                }
+                var includeIds = Object.values(this.filters).reduce((set, ids) => { ids.forEach(set.add, set); return set; }, new Set());
+                // console.log(includeIds.values());
+                return includeIds.has(dataset.get('_id'));
+            })
+            .groupBy(this.getSourceName)
             .mapObject((datasets, key) => {
                 return _.groupBy(datasets, (dataset) => {
                     return dataset.get('meta').minerva.category || 'Other';

--- a/web_external/views/body/LayersPanel.js
+++ b/web_external/views/body/LayersPanel.js
@@ -4,6 +4,7 @@ import Panel from '../body/Panel';
 import ChoroplethRenderWidget from '../widgets/ChoroplethRenderWidget';
 import JsonConfigWidget from '../widgets/JsonConfigWidget';
 import KTileConfigWidget from '../widgets/KTileConfigWidget';
+import { getBoundSupported } from '../util/utils';
 
 import template from '../../templates/body/layersPanel.pug';
 import '../../stylesheets/body/layersPanel.styl';
@@ -309,7 +310,8 @@ const LayersPanel = Panel.extend({
 
         this.update(template({
             datasets: sortedDisplayedDatasets,
-            layersOrderOptions: this.layersOrderOptions
+            layersOrderOptions: this.layersOrderOptions,
+            getBoundSupported: getBoundSupported
         }));
 
         return this;

--- a/web_external/views/map/MapPanel.js
+++ b/web_external/views/map/MapPanel.js
@@ -327,7 +327,7 @@ const MapPanel = Panel.extend({
                 });
                 layer.geoOn(geo.event.annotation.state, (e) => {
                     bootbox.prompt({
-                        title: 'Give dataset a name?',
+                        title: 'Boundary dataset name',
                         value: 'Boundary',
                         callback: (name) => {
                             if (name !== null) {

--- a/web_external/views/map/MapPanel.js
+++ b/web_external/views/map/MapPanel.js
@@ -1,6 +1,7 @@
 import _ from 'underscore';
 import geo from 'geojs';
 import colorbrewer from 'colorbrewer';
+import bootbox from 'bootbox';
 
 import events from '../../events';
 import Panel from '../body/Panel';
@@ -325,13 +326,16 @@ const MapPanel = Panel.extend({
                     showLabels: false
                 });
                 layer.geoOn(geo.event.annotation.state, (e) => {
-                    setTimeout(() => {
-                        var name = prompt('Dataset name?', 'Boundary');
-                        if (name !== null) {
-                            events.trigger('m:dataset-drawn', name, layer.geojson().features[0].geometry);
+                    bootbox.prompt({
+                        title: 'Give dataset a name?',
+                        value: 'Boundary',
+                        callback: (name) => {
+                            if (name !== null) {
+                                events.trigger('m:dataset-drawn', name, layer.geojson().features[0].geometry);
+                            }
+                            layer.removeAllAnnotations();
                         }
-                        layer.removeAllAnnotations();
-                    }, 100);
+                    });
                 });
                 this.drawDatasetLayer = layer;
             }

--- a/web_external/views/map/MapPanel.js
+++ b/web_external/views/map/MapPanel.js
@@ -328,7 +328,7 @@ const MapPanel = Panel.extend({
                     setTimeout(() => {
                         var name = prompt('Dataset name?', 'Boundary');
                         if (name !== null) {
-                            events.trigger('m:dataset-drawn', layer.geojson().features[0].geometry);
+                            events.trigger('m:dataset-drawn', name, layer.geojson().features[0].geometry);
                         }
                         layer.removeAllAnnotations();
                     }, 100);
@@ -336,7 +336,6 @@ const MapPanel = Panel.extend({
                 this.drawDatasetLayer = layer;
             }
             this.drawDatasetLayer.mode('rectangle');
-
         });
 
         Panel.prototype.initialize.apply(this);

--- a/web_external/views/map/MapPanel.js
+++ b/web_external/views/map/MapPanel.js
@@ -318,11 +318,32 @@ const MapPanel = Panel.extend({
             this.map.center(center);
         });
 
+        this.listenTo(events, 'm:draw-boundary-dataset', () => {
+            if (!this.drawDatasetLayer) {
+                var layer = this.map.createLayer('annotation', {
+                    annotations: ['rectangle'],
+                    showLabels: false
+                });
+                layer.geoOn(geo.event.annotation.state, (e) => {
+                    setTimeout(() => {
+                        var name = prompt('Dataset name?', 'Boundary');
+                        if (name !== null) {
+                            events.trigger('m:dataset-drawn', layer.geojson().features[0].geometry);
+                        }
+                        layer.removeAllAnnotations();
+                    }, 100);
+                });
+                this.drawDatasetLayer = layer;
+            }
+            this.drawDatasetLayer.mode('rectangle');
+
+        });
+
         Panel.prototype.initialize.apply(this);
     },
 
     drawDatasetBounds() {
-        this.annotationLayer = this.map.createLayer('annotation', {
+        this.boundariesAnnotationLayer = this.map.createLayer('annotation', {
             annotations: ['rectangle'],
             showLabels: this.showBoundsDatasetLabel
         });
@@ -358,17 +379,17 @@ const MapPanel = Panel.extend({
                 }
             };
         });
-        this.annotationLayer.geojson({
+        this.boundariesAnnotationLayer.geojson({
             'type': 'FeatureCollection',
             'features': features
         });
     },
 
     removeDatasetBounds() {
-        if (this.annotationLayer) {
-            this.annotationLayer.removeAllAnnotations();
-            this.map.deleteLayer(this.annotationLayer);
-            this.annotationLayer = null;
+        if (this.boundariesAnnotationLayer) {
+            this.boundariesAnnotationLayer.removeAllAnnotations();
+            this.map.deleteLayer(this.boundariesAnnotationLayer);
+            this.boundariesAnnotationLayer = null;
         }
     },
 

--- a/web_external/views/util/utils.js
+++ b/web_external/views/util/utils.js
@@ -10,4 +10,12 @@ function generateSequence(start, stop, count) {
     return sequence;
 }
 
-export { generateSequence };
+function getBoundSupported(dataset) {
+    var minervaMetadata = dataset.metadata();
+    return ['geojson', 'geotiff', 'geojson-timeseries'].indexOf(minervaMetadata.dataset_type) !== -1;
+}
+
+export {
+    generateSequence,
+    getBoundSupported
+};


### PR DESCRIPTION
Utilize GeoJS annotation layer for boundary dataset creating. 
Uses bounding box support based on the previous PRs for intersecting filtering.

![2017-12-14_13-11-32](https://user-images.githubusercontent.com/3123478/34007748-e88e030e-e0d0-11e7-9fd5-7c0f9a396fda.gif)