### PR TITLE
Change the Dataset sharing to based on User Group instead of Public folder

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -6,7 +6,8 @@
         "gravatar",
         "jobs",
         "database_assetstore",
-        "girder_ktile"
+        "girder_ktile",
+        "autojoin"
     ],
     "npm": {
         "file": "package.json",

--- a/plugin_tests/dataset_test.py
+++ b/plugin_tests/dataset_test.py
@@ -385,7 +385,6 @@ class DatasetTestCase(base.TestCase):
         geojsonContent = response.json
         self.assertEqual(len(geojsonContent['features'][0]['geometry']['coordinates']), 245)
 
-
         # test new dataset download endpoint
         response = self.request(
             path='/minerva_dataset/{0}/bound'.format(stateItemId),
@@ -397,3 +396,15 @@ class DatasetTestCase(base.TestCase):
         self.assertEqual(geojsonContent['lry'], 31.332502)
         self.assertEqual(geojsonContent['ulx'], -114.813613)
         self.assertEqual(geojsonContent['uly'], 41.003444)
+
+    def testPrepareDatasetSharing(self):
+        self.assertEqual(len(self.request(path='/group', user=self._user, method='GET').json), 0)
+        response = self.request(path='/minerva_dataset/prepare_sharing',
+                                method='POST',
+                                user=self._user)
+        groups = self.request(path='/group', user=self._user, method='GET').json
+
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0]['name'], 'dataset sharing')
+        self.assertEqual(groups[0]['public'], False)
+        self.assertStatusOk(response)

--- a/plugin_tests/web_client_test.py
+++ b/plugin_tests/web_client_test.py
@@ -25,3 +25,11 @@ class WebClientTestCase(web_client_test.WebClientTestCase):
         item = self.model('item').findOne({'name': 'raster.tiff'})
         self.request(path='/minerva_dataset/' +
                      str(item['_id']) + '/item', method='POST', user=admin)
+
+        # Create the user group for sharing feature
+        groupModel = self.model('group')
+        datasetSharingGroup = groupModel.findOne(query={
+            'name': 'dataset sharing'
+        })
+        if not datasetSharingGroup:
+            groupModel.createGroup('dataset sharing', admin, public=False)

--- a/plugin_tests/web_client_test.py
+++ b/plugin_tests/web_client_test.py
@@ -27,9 +27,4 @@ class WebClientTestCase(web_client_test.WebClientTestCase):
                      str(item['_id']) + '/item', method='POST', user=admin)
 
         # Create the user group for sharing feature
-        groupModel = self.model('group')
-        datasetSharingGroup = groupModel.findOne(query={
-            'name': 'dataset sharing'
-        })
-        if not datasetSharingGroup:
-            groupModel.createGroup('dataset sharing', admin, public=False)
+        self.request(path='/minerva_dataset/prepare_sharing', method='POST', user=admin)

--- a/server/constants.py
+++ b/server/constants.py
@@ -22,6 +22,8 @@ class PluginSettings():
     MINERVA_COLLECTION = 'minerva'
     MINERVA_FOLDER = 'minerva'
     DATASET_FOLDER = 'dataset'
+    MINERVA_SHARED_DATASET = 'minerva_shared_dataset'
+    DATASET_SHARING_GROUP_NAME = 'dataset sharing'
     SOURCE_FOLDER = 'source'
     SESSION_FOLDER = 'session'
     GEOJSON_EXTENSION = '.geojson'

--- a/server/utility/minerva_utility.py
+++ b/server/utility/minerva_utility.py
@@ -28,8 +28,9 @@ def findNamedFolder(currentUser, user, parent, parentType, name, create=False,
                     joinShareGroup=None, public=False):
     folders = \
         [ModelImporter.model('folder').filter(folder, currentUser) for folder in
-         ModelImporter.model('folder').childFolders(parent=parent,
-            parentType=parentType, user=currentUser, filters={'name': name})]
+         ModelImporter.model('folder').childFolders(
+            parent=parent, parentType=parentType,
+            user=currentUser, filters={'name': name})]
     # folders should have len of 0 or 1, since we are looking in a
     # user folder for a folder with a certain name
     if len(folders) == 0:
@@ -92,7 +93,6 @@ def findSharedDatasetFolders(currentUser):
             PluginSettings.DATASET_SHARING_GROUP_NAME))
 
     folders = folderModel.find({
-        'public': False,
         'baseParentType': 'user',
         'parentCollection': 'user',
         'access.groups.id': datasetSharingGroup['_id'],


### PR DESCRIPTION
This PR adds two dependencies to the autojoin and user group.
Based on current observation, the undergoing auto provisioning could include these new dependencies.
