### PR TITLE
Postgres builder preview

### DIFF
--- a/server/rest/dataset.py
+++ b/server/rest/dataset.py
@@ -537,7 +537,8 @@ class Dataset(Resource):
             return func
         elif geometryField['type'] == 'link':
             records = json.loads(''.join(list(func())))
-            featureCollection = self.linkAndAssembleGeometry(geometryField['links'], geometryField['itemId'], records)
+            featureCollection = self.linkAndAssembleGeometry(
+                geometryField['links'], geometryField['itemId'], records)
             if len(featureCollection.features) == 0:
                 raise GirderException('Dataset is empty')
             return featureCollection
@@ -563,7 +564,7 @@ class Dataset(Resource):
             if skip:
                 continue
             try:
-                key = ''.join([feature['properties'][x['field']] for x in valueLinks])
+                key = ''.join([str(feature['properties'][x['field']]) for x in valueLinks])
             except KeyError:
                 raise GirderException('missing property for key ' +
                                       x['field'] + ' in geometry link target geojson')
@@ -571,7 +572,7 @@ class Dataset(Resource):
 
         assembled = []
         for record in records:
-            key = ''.join([record[x['value']] for x in valueLinks])
+            key = ''.join([str(record[x['value']]) for x in valueLinks])
             if key in mappedGeometries:
                 assembled.append(
                     geojson.Feature(geometry=mappedGeometries[key], properties=record)

--- a/server/rest/dataset.py
+++ b/server/rest/dataset.py
@@ -557,12 +557,13 @@ class Dataset(Resource):
         mappedGeometries = {}
         linkingDuplicateCount = 0
         for feature in featureCollections['features']:
-            skip = False
+            skipCurrentFeature = False
             for constantLink in constantLinks:
                 if feature['properties'][constantLink['field']] != constantLink['value']:
-                    skip = True
+                    # If the feature dones't satisfy any constant linking condition
+                    skipCurrentFeature = True
                     break
-            if skip:
+            if skipCurrentFeature:
                 continue
             try:
                 key = ''.join([str(feature['properties'][x['field']]) for x in valueLinks])

--- a/server/rest/postgres_geojson.py
+++ b/server/rest/postgres_geojson.py
@@ -226,7 +226,7 @@ class PostgresGeojson(Resource):
     @access.user
     @loadmodel(model='assetstore', map={'assetstoreId': 'assetstore'})
     @describeRoute(
-        Description('Get metadata for result')
+        Description('Query metadata of result')
         .param('assetstoreId', 'assetstore ID of the target database')
         .param('table', 'Table name from the database')
         .param('field', 'Field to which the aggregate function will be applied')
@@ -234,10 +234,6 @@ class PostgresGeojson(Resource):
         .param('filter', 'Filter condition object for filtering table data')
         .param('geometryField', 'Geometry data definition object')
     )
-    # This endpoint is very similar to createPostgresGeojsonDataset
-    # but because preview doesn't need actual GeoJSON or
-    # a long-term use dataset, and it returns meta of the result
-    # instead of the actual result, this endpoint is created.
     def resultMetadata(self, assetstore, params):
         filter = params['filter']
         table = params['table']
@@ -310,7 +306,7 @@ class PostgresGeojson(Resource):
             records = list(query[0]())
 
             dataset = Dataset()
-            assembled = dataset.linkAndAssembleGeometry(
+            assembled, linkingDuplicateCount = dataset.linkAndAssembleGeometry(
                 geometryField['links'], geometryField['itemId'], records)
             recordCountAfterGeometryLinking = len(assembled.features)
             recordCount = recordCountAfterGeometryLinking
@@ -320,6 +316,7 @@ class PostgresGeojson(Resource):
             'recordCountAfterFilter': recordCountAfterFilter,
             'recordCountAfterAggregation': recordCountAfterAggregation,
             'recordCountAfterGeometryLinking': recordCountAfterGeometryLinking,
+            'linkingDuplicate': linkingDuplicateCount,
             'recordCount': recordCount
         }
 

--- a/web_external/stylesheets/widgets/postgresWidget.styl
+++ b/web_external/stylesheets/widgets/postgresWidget.styl
@@ -69,3 +69,8 @@
       .rule-value-container
         border none
         padding-left 0
+
+  .metadata-container
+    text-align left
+    margin-bottom 15px
+    margin-left 10px

--- a/web_external/templates/widgets/postgresWidget.pug
+++ b/web_external/templates/widgets/postgresWidget.pug
@@ -117,14 +117,14 @@
               -   arr.push(`After geometry linking: ${metadata.recordCountAfterGeometryLinking}`)
               - }
               - var output = arr.join(',&nbsp;&nbsp;')
-              | (!{output})
+              | !{output}
             if metadata.linkingDuplicate
-              div(title='With current linking conditions, there are duplicate records in geometry linking dataset, consider using a different dataset or adding more conditions.') (Linking duplicate: #{metadata.linkingDuplicate})
+              div(title='With current linking conditions, there are duplicate records in geometry linking dataset, consider using a different dataset or adding more conditions.') Linking duplicate: #{metadata.linkingDuplicate}
 
         a.btn.btn-small.btn-default(data-dismiss="modal") Cancel
         button#result-metadata.btn.btn-small.btn-primary(disabled=!columns.length || metadataPending, type="button")
           i.icon-search
-          | Metadata
+          | Inspect query
         button#create-dataset.btn.btn-small.btn-primary(disabled=!columns.length || !metadata || metadata.recordCount===0, title= !metadata ? 'Query result metadata first' : '')
           i.icon-plus-squared
           | Dataset

--- a/web_external/templates/widgets/postgresWidget.pug
+++ b/web_external/templates/widgets/postgresWidget.pug
@@ -118,6 +118,9 @@
               - }
               - var output = arr.join(',&nbsp;&nbsp;')
               | (!{output})
+            if metadata.linkingDuplicate
+              div(title='With current linking conditions, there are duplicate records in geometry linking dataset, consider using a different dataset or adding more conditions.') (Linking duplicate: #{metadata.linkingDuplicate})
+
         a.btn.btn-small.btn-default(data-dismiss="modal") Cancel
         button#result-metadata.btn.btn-small.btn-primary(disabled=!columns.length || metadataPending, type="button")
           i.icon-search

--- a/web_external/templates/widgets/postgresWidget.pug
+++ b/web_external/templates/widgets/postgresWidget.pug
@@ -110,3 +110,6 @@
         button#m-get-geojson.btn.btn-small.btn-primary(disabled=!columns.length)
           i.icon-plus-squared
           | Get geometry
+        button#m-preview.btn.btn-small.btn-primary(disabled=!columns.length)
+          i.icon-plus-squared
+          | Preview

--- a/web_external/templates/widgets/postgresWidget.pug
+++ b/web_external/templates/widgets/postgresWidget.pug
@@ -106,10 +106,22 @@
                     .span.help-block Invalid
         .m-query-builder
       .modal-footer
+        .metadata-container.text-info
+          if metadataPending
+            | Querying result metadata...
+          if metadata
+            div Record count: #{metadata.recordCount}
+            div
+              - var arr = [`Total: ${metadata.recordCountInTable}`, `After filter: ${metadata.recordCountAfterFilter}`, `After aggregation: ${metadata.recordCountAfterAggregation}`];
+              - if(metadata.recordCountAfterGeometryLinking !== null){
+              -   arr.push(`After geometry linking: ${metadata.recordCountAfterGeometryLinking}`)
+              - }
+              - var output = arr.join(',&nbsp;&nbsp;')
+              | (!{output})
         a.btn.btn-small.btn-default(data-dismiss="modal") Cancel
-        button#m-get-geojson.btn.btn-small.btn-primary(disabled=!columns.length)
+        button#result-metadata.btn.btn-small.btn-primary(disabled=!columns.length || metadataPending, type="button")
+          i.icon-search
+          | Metadata
+        button#create-dataset.btn.btn-small.btn-primary(disabled=!columns.length || !metadata || metadata.recordCount===0, title= !metadata ? 'Query result metadata first' : '')
           i.icon-plus-squared
-          | Get geometry
-        button#m-preview.btn.btn-small.btn-primary(disabled=!columns.length)
-          i.icon-plus-squared
-          | Preview
+          | Dataset


### PR DESCRIPTION
The PR add a feature to see query result metadata.

The first commit refactor the existing code to make it more generic across file geojson, postgres geojson, and timeseries-geosjon datasets. This changed involved a few moving parts but they reconciled now. 

The other two commit implement a server-side endpoint for getting the result metadata and the client GUI. Due to performance consideration, the result metadata is retrieved on request. Also, it requests the user to request the result metadata before creating the dataset to catch query issue early.

![2018-02-28_10-31-36](https://user-images.githubusercontent.com/3123478/36796106-c3c8d372-1c72-11e8-9c41-19a8f2816669.gif)

===Updated===
![chrome_2018-03-06_11-04-13](https://user-images.githubusercontent.com/3123478/37043294-49d6dfa8-212e-11e8-90b1-c9df0e76eb38.png)
