### PR TITLE
Add missed geotiff layer color legend title

### DIFF
--- a/web_external/views/adapters/LargeImageRepresentation.js
+++ b/web_external/views/adapters/LargeImageRepresentation.js
@@ -30,6 +30,7 @@ class LargeImageRepresentation extends MapRepresentation {
             }));
             layer.url((x, y, z) => `${url}/${z}/${x}/${y}?${params}&style=${style}`);
             var colorLegendCategory = {
+                name: `${dataset.get('name')} - band ${visProperties.band}`,
                 type: 'discrete',
                 scale: 'linear',
                 colors: palettableColorbrewerMapper.toRampColors(visProperties.palettable),


### PR DESCRIPTION
The Geotiff color legend title was missed by mistake. This PR fixes that.