### PR TITLE
Fix downloading database data.

### DIFF
--- a/server/rest/dataset.py
+++ b/server/rest/dataset.py
@@ -525,7 +525,7 @@ class Dataset(Resource):
             func = self.model('file').download(file, headers=False)
         else:
             func = self._getPostgresGeojsonData(item)
-        if funcAllowed:
+        if not callable(func) or funcAllowed:
             return func
         return geojson.loads(''.join(list(func())))
 

--- a/server/rest/dataset.py
+++ b/server/rest/dataset.py
@@ -507,9 +507,9 @@ class Dataset(Resource):
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied on the parent folder.', 403))
     def download(self, item, params):
-        return self.downloadDataset(item)
+        return self.downloadDataset(item, funcAllowed=True)
 
-    def downloadDataset(self, item):
+    def downloadDataset(self, item, funcAllowed=False):
         minervaMeta = item['meta']['minerva']
         if not minervaMeta.get('postgresGeojson'):
             fileId = None
@@ -523,9 +523,11 @@ class Dataset(Resource):
                 fileId = minervaMeta['geo_render']['file_id']
             file = self.model('file').load(fileId, force=True)
             func = self.model('file').download(file, headers=False)
-            return geojson.loads(''.join(list(func())))
         else:
-            return self._getPostgresGeojsonData(item)
+            func = self._getPostgresGeojsonData(item)
+        if funcAllowed:
+            return func
+        return geojson.loads(''.join(list(func())))
 
     def _getPostgresGeojsonData(self, item):
         user = self.getCurrentUser()

--- a/server/rest/dataset.py
+++ b/server/rest/dataset.py
@@ -522,12 +522,12 @@ class Dataset(Resource):
             else:
                 fileId = minervaMeta['geo_render']['file_id']
             file = self.model('file').load(fileId, force=True)
-            func = self.model('file').download(file, headers=False)
+            result = self.model('file').download(file, headers=False)
         else:
-            func = self._getPostgresGeojsonData(item)
-        if not callable(func) or funcAllowed:
-            return func
-        return geojson.loads(''.join(list(func())))
+            result = self._getPostgresGeojsonData(item)
+        if not callable(result) or funcAllowed:
+            return result
+        return geojson.loads(''.join(list(result())))
 
     def _getPostgresGeojsonData(self, item):
         user = self.getCurrentUser()


### PR DESCRIPTION
Most of the internal calls to `downloadDataset` expect a decoded geojson object, but, for databases, we returned a generator function.  For non-database datasets, when we downloaded the data, we first decoded the geojson to an object, then reencoded it to json as part of the endpoint processing.  This fixes the internal use of the database dataset and avoids the waste of reencoding non-database datasets.

Until we add test infrastructure for the database, you can manually verify this by try to zoom to the bounds of a database dataset.