### PR TITLE
Pin dependency bootstrap-select version

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "JSONPath": "0.10.0",
     "bootbox": "^4.4.0",
-    "bootstrap-select": "^1.10.0",
+    "bootstrap-select": "1.12.4",
     "bootstrap-slider": "^7.1.0",
     "colorbrewer": "1.0.0",
     "dot": "^1.1.2",


### PR DESCRIPTION
Pin dependency bootstrap-select version because it has a tendency to introduce breaking changes